### PR TITLE
fix: handle TTL correctly, implement minimum TTL

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,10 @@ This value file will run webhook server along with external-dns as sidecar.
 | WEBHOOK_APITOKEN       | deSEC API token                    | Mandatory         |
 | WEBHOOK_DRYRUN         | If set, changes won't be applied   | Default: `false`  |
 | WEBHOOK_DOMAINFILTERS  | List of domains to manage, comma separated          | Mandatory         |
+| WEBHOOK_DEFAULTTTL     | Default TTL if not specified       | Default: `3600`  |
+
+> [!NOTE]   
+> deSEC requires a minimum TTL of 3600 seconds (https://desec.readthedocs.io/en/latest/dns/domains.html#domain-object)
 
 ### Server Configuration
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -11,6 +11,7 @@ type Config struct {
 	APIToken      string   `required:"true"`
 	DryRun        bool     `default:"false"`
 	DomainFilters []string `required:"true"`
+	DefaultTTL    int      `default:"3600"`
 
 	WebhookAddress string `default:"127.0.0.1"`
 	WebhookPort    int    `default:"8888"`

--- a/internal/provider/desec_test.go
+++ b/internal/provider/desec_test.go
@@ -261,13 +261,12 @@ func TestConvertEndpointToRRSetExtended(t *testing.T) {
 				DNSName:    "example.com",
 				RecordType: "A",
 				Targets:    endpoint.Targets{"192.0.2.1"},
-				RecordTTL:  300,
 			},
 			expected: &desec.RRSet{
 				SubName: "",
 				Type:    "A",
 				Records: []string{"192.0.2.1"},
-				TTL:     300,
+				TTL:     3600,
 			},
 		},
 		{
@@ -276,13 +275,12 @@ func TestConvertEndpointToRRSetExtended(t *testing.T) {
 				DNSName:    "www.example.com",
 				RecordType: "A",
 				Targets:    endpoint.Targets{"192.0.2.1", "192.0.2.2"},
-				RecordTTL:  300,
 			},
 			expected: &desec.RRSet{
 				SubName: "www",
 				Type:    "A",
 				Records: []string{"192.0.2.1", "192.0.2.2"},
-				TTL:     300,
+				TTL:     3600,
 			},
 		},
 		{
@@ -291,13 +289,12 @@ func TestConvertEndpointToRRSetExtended(t *testing.T) {
 				DNSName:    "www.example.com",
 				RecordType: "CNAME",
 				Targets:    endpoint.Targets{"alias.example.com"},
-				RecordTTL:  300,
 			},
 			expected: &desec.RRSet{
 				SubName: "www",
 				Type:    "CNAME",
 				Records: []string{"alias.example.com."},
-				TTL:     300,
+				TTL:     3600,
 			},
 		},
 		{
@@ -306,13 +303,12 @@ func TestConvertEndpointToRRSetExtended(t *testing.T) {
 				DNSName:    "www.example.com",
 				RecordType: "CNAME",
 				Targets:    endpoint.Targets{"alias.example.com."},
-				RecordTTL:  300,
 			},
 			expected: &desec.RRSet{
 				SubName: "www",
 				Type:    "CNAME",
 				Records: []string{"alias.example.com."},
-				TTL:     300,
+				TTL:     3600,
 			},
 		},
 		{
@@ -321,7 +317,6 @@ func TestConvertEndpointToRRSetExtended(t *testing.T) {
 				DNSName:    "_dmarc.example.com",
 				RecordType: "TXT",
 				Targets:    endpoint.Targets{"v=DMARC1; p=reject"},
-				RecordTTL:  3600,
 			},
 			expected: &desec.RRSet{
 				SubName: "_dmarc",
@@ -330,11 +325,41 @@ func TestConvertEndpointToRRSetExtended(t *testing.T) {
 				TTL:     3600,
 			},
 		},
+		{
+			name: "A record with TTL lower than minimum",
+			input: &endpoint.Endpoint{
+				DNSName:    "example.com",
+				RecordType: "A",
+				Targets:    endpoint.Targets{"192.0.2.1"},
+				RecordTTL:  300,
+			},
+			expected: &desec.RRSet{
+				SubName: "",
+				Type:    "A",
+				Records: []string{"192.0.2.1"},
+				TTL:     3600,
+			},
+		},
+		{
+			name: "A record with 2-hour TTL",
+			input: &endpoint.Endpoint{
+				DNSName:    "example.com",
+				RecordType: "A",
+				Targets:    endpoint.Targets{"192.0.2.1"},
+				RecordTTL:  7200,
+			},
+			expected: &desec.RRSet{
+				SubName: "",
+				Type:    "A",
+				Records: []string{"192.0.2.1"},
+				TTL:     7200,
+			},
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result := convertEndpointToRRSet(tt.input)
+			result := convertEndpointToRRSet(tt.input, 3600)
 			if !reflect.DeepEqual(result, tt.expected) {
 				t.Errorf("convertEndpointToRRSet() = %+v, want %+v", result, tt.expected)
 			}


### PR DESCRIPTION
deSEC only supports DNS records with TTL >= 3600 seconds.

This PR implements:
- `WEBHOOK_DEFAULTTTL` config to 3600 seconds
- Automatically set `config.DefaultTTL` to minimum if is lower than 3600 seconds
- Automatically set `ep.RecordTTL` coming from ExternalDNS if it does not exist or is less than 3600 seconds