### PR TITLE
fix(provider): strip trailing dot from /records DNSName

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,9 +19,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version: "1.25"
       - name: golangci-lint
@@ -45,13 +45,13 @@ jobs:
             runner: ubuntu-24.04-arm
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Log into registry ${{ env.REGISTRY }}
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -59,7 +59,7 @@ jobs:
 
       - name: Build and push by digest
         id: build
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: .
           platforms: ${{ matrix.platform }}
@@ -76,7 +76,7 @@ jobs:
           touch "/tmp/digests/${digest#sha256:}"
 
       - name: Upload digest
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: digests-ci-${{ matrix.runner }}
           path: /tmp/digests/*
@@ -89,17 +89,17 @@ jobs:
     needs: docker
     steps:
       - name: Download digests
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           path: /tmp/digests
           pattern: digests-ci-*
           merge-multiple: true
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Log into registry ${{ env.REGISTRY }}
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -135,7 +135,7 @@ jobs:
           echo "digest=$DIGEST" >> "$GITHUB_OUTPUT"
 
       - name: Install cosign
-        uses: sigstore/cosign-installer@v4
+        uses: sigstore/cosign-installer@v4.0.0
         with:
           cosign-release: "v3.0.6"
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -137,7 +137,7 @@ jobs:
       - name: Install cosign
         uses: sigstore/cosign-installer@v4
         with:
-          cosign-release: "v2.2.4"
+          cosign-release: "v3.0.6"
 
       - name: Sign the published Docker image
         if: ${{ github.event_name != 'pull_request' }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,10 +45,10 @@ jobs:
           fi
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Log into registry ${{ env.REGISTRY }}
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -56,7 +56,7 @@ jobs:
 
       - name: Build and push by digest
         id: build
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: .
           platforms: ${{ matrix.platform }}
@@ -73,7 +73,7 @@ jobs:
           touch "/tmp/digests/${digest#sha256:}"
 
       - name: Upload digest
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: digests-release-${{ matrix.runner }}
           path: /tmp/digests/*
@@ -90,7 +90,7 @@ jobs:
       id-token: write
     steps:
       - name: Download digests
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           path: /tmp/digests
           pattern: digests-release-*
@@ -105,10 +105,10 @@ jobs:
           fi
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Log into registry ${{ env.REGISTRY }}
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -116,7 +116,7 @@ jobs:
 
       - name: Extract Docker metadata
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
@@ -135,7 +135,7 @@ jobs:
           echo "digest=$DIGEST" >> "$GITHUB_OUTPUT"
 
       - name: Install cosign
-        uses: sigstore/cosign-installer@v3
+        uses: sigstore/cosign-installer@v4
         with:
           cosign-release: "v2.2.4"
 
@@ -147,7 +147,7 @@ jobs:
         run: echo "${TAGS}" | xargs -I {} cosign sign --yes {}@${DIGEST}
 
       - name: Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         if: github.ref_type == 'tag'
         with:
           generate_release_notes: true

--- a/internal/provider/desec.go
+++ b/internal/provider/desec.go
@@ -308,14 +308,19 @@ func convertRRSetToEndpoint(rrset *desec.RRSet, domain string) *endpoint.Endpoin
 		return nil
 	}
 
-	// Compose DNSName from subname and domain
+	// Compose DNSName from subname and domain. external-dns sources emit
+	// DNSName without a trailing dot, and external-dns's TXT registry
+	// matches companion records by exact-string DNSName -- if /records
+	// returns a dotted form, the registry sets providerSpecific
+	// txt/force-update=true on every reconcile and the plan calculator
+	// emits a no-op Update for every record.
 	var dnsName string
 	if rrset.SubName == "" {
 		dnsName = domain
 	} else {
 		dnsName = rrset.SubName + "." + domain
 	}
-	dnsName = strings.TrimSuffix(dnsName, ".") + "."
+	dnsName = strings.TrimSuffix(dnsName, ".")
 
 	targets := make(endpoint.Targets, len(rrset.Records))
 	copy(targets, rrset.Records)

--- a/internal/provider/desec.go
+++ b/internal/provider/desec.go
@@ -2,7 +2,9 @@ package provider
 
 import (
 	"context"
+	"net/http"
 	"strings"
+	"time"
 
 	"github.com/michelangelomo/external-dns-desec-provider/internal/config"
 	"github.com/nrdcg/desec"
@@ -18,6 +20,7 @@ type DesecClient struct {
 	dryRun        bool
 	defaultTTL    int
 	domainFilters []string
+	rateLimit     *rateLimitTracker
 }
 
 const (
@@ -30,13 +33,26 @@ func CreateDesecClient(config config.Config) (*DesecClient, error) {
 		config.DefaultTTL = minimumTTL
 	}
 
+	tracker := newRateLimitTracker()
+	httpClient := &http.Client{
+		Timeout: 10 * time.Second,
+		Transport: &rateLimitTransport{
+			inner:   http.DefaultTransport,
+			tracker: tracker,
+		},
+	}
+
 	ctx := context.Background()
 	client := &DesecClient{
-		client:        desec.New(config.APIToken, desec.ClientOptions{RetryMax: 2}),
+		client: desec.New(config.APIToken, desec.ClientOptions{
+			RetryMax:   2,
+			HTTPClient: httpClient,
+		}),
 		ctx:           ctx,
 		dryRun:        config.DryRun,
 		defaultTTL:    config.DefaultTTL,
 		domainFilters: config.DomainFilters,
+		rateLimit:     tracker,
 	}
 	return client, nil
 }
@@ -69,6 +85,11 @@ func (d *DesecClient) GetEndpoints(domain string) ([]*endpoint.Endpoint, error) 
 }
 
 func (d *DesecClient) ApplyChanges(changes plan.Changes) error {
+	if remaining := d.rateLimit.wait(); remaining > 0 {
+		log.Warnf("deSEC rate limit active; skipping ApplyChanges for %s to preserve daily quota", remaining)
+		return &RateLimitError{RetryAfter: remaining}
+	}
+
 	log.Debugf("applying changes: %d creates, %d updates, %d deletes",
 		len(changes.Create), len(changes.UpdateNew), len(changes.Delete))
 

--- a/internal/provider/desec_test.go
+++ b/internal/provider/desec_test.go
@@ -476,7 +476,7 @@ func TestConvertRRSetToEndpointExtended(t *testing.T) {
 			},
 			domain: "example.com",
 			expected: &endpoint.Endpoint{
-				DNSName:    "www.example.com.",
+				DNSName:    "www.example.com",
 				RecordType: "A",
 				Targets:    endpoint.Targets{"192.0.2.1", "192.0.2.2"},
 				RecordTTL:  300,
@@ -492,14 +492,14 @@ func TestConvertRRSetToEndpointExtended(t *testing.T) {
 			},
 			domain: "example.com",
 			expected: &endpoint.Endpoint{
-				DNSName:    "_dmarc.example.com.",
+				DNSName:    "_dmarc.example.com",
 				RecordType: "TXT",
 				Targets:    endpoint.Targets{"v=DMARC1; p=reject"},
 				RecordTTL:  3600,
 			},
 		},
 		{
-			name: "Domain with trailing dot",
+			name: "Apex record with dotted domain still emits dotless DNSName",
 			input: &desec.RRSet{
 				SubName: "",
 				Type:    "A",
@@ -508,7 +508,7 @@ func TestConvertRRSetToEndpointExtended(t *testing.T) {
 			},
 			domain: "example.com.",
 			expected: &endpoint.Endpoint{
-				DNSName:    "example.com.",
+				DNSName:    "example.com",
 				RecordType: "A",
 				Targets:    endpoint.Targets{"192.0.2.1"},
 				RecordTTL:  300,
@@ -782,6 +782,40 @@ func TestAdjustEndpoints(t *testing.T) {
 
 			if !reflect.DeepEqual(result, tt.expected) {
 				t.Errorf("AdjustEndpoints() = %+v, want %+v", result, tt.expected)
+			}
+		})
+	}
+}
+
+// TestConvertRRSetToEndpoint_DNSNameHasNoTrailingDot pins the read-path
+// invariant that prevents the providerSpecific txt/force-update=true loop:
+// external-dns sources emit DNSName without a trailing dot, and the TXT
+// registry matches companion records by exact-string DNSName. If /records
+// returns a dotted form, every reconcile produces a no-op Update on every
+// record (observed in deploy as "0 creates, 10 updates, 0 deletes").
+func TestConvertRRSetToEndpoint_DNSNameHasNoTrailingDot(t *testing.T) {
+	cases := []struct {
+		name    string
+		subname string
+		domain  string
+		want    string
+	}{
+		{"subdomain", "www", "example.com", "www.example.com"},
+		{"apex", "", "example.com", "example.com"},
+		{"deep subdomain", "foo.bar", "example.com", "foo.bar.example.com"},
+		{"domain passed with trailing dot still strips", "www", "example.com.", "www.example.com"},
+		{"apex with domain trailing dot still strips", "", "example.com.", "example.com"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			ep := convertRRSetToEndpoint(&desec.RRSet{
+				SubName: tc.subname,
+				Type:    "A",
+				Records: []string{"192.0.2.1"},
+				TTL:     3600,
+			}, tc.domain)
+			if ep.DNSName != tc.want {
+				t.Errorf("DNSName = %q, want %q", ep.DNSName, tc.want)
 			}
 		})
 	}

--- a/internal/provider/ratelimit.go
+++ b/internal/provider/ratelimit.go
@@ -1,0 +1,95 @@
+package provider
+
+import (
+	"fmt"
+	"net/http"
+	"strconv"
+	"sync"
+	"time"
+)
+
+// RateLimitError is returned when a deSEC API call is short-circuited because
+// the client is still inside a throttle window observed from a prior 429
+// response. Returning this instead of hitting the API prevents the daily quota
+// from being burned while external-dns keeps retrying.
+type RateLimitError struct {
+	RetryAfter time.Duration
+}
+
+func (e *RateLimitError) Error() string {
+	return fmt.Sprintf("deSEC rate limit active, retry after %s", e.RetryAfter)
+}
+
+// rateLimitTracker remembers the next time the client should attempt to call
+// the deSEC API, derived from Retry-After headers seen on 429 responses.
+type rateLimitTracker struct {
+	mu            sync.Mutex
+	nextAllowedAt time.Time
+	now           func() time.Time
+}
+
+func newRateLimitTracker() *rateLimitTracker {
+	return &rateLimitTracker{now: time.Now}
+}
+
+// record extends the throttle window. A shorter delay than the current
+// deadline is ignored so a later 429 with a smaller Retry-After can't shorten
+// a longer window already in effect.
+func (t *rateLimitTracker) record(d time.Duration) {
+	if d <= 0 {
+		return
+	}
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	deadline := t.now().Add(d)
+	if deadline.After(t.nextAllowedAt) {
+		t.nextAllowedAt = deadline
+	}
+}
+
+// wait returns the remaining throttle duration; 0 means the client may proceed.
+func (t *rateLimitTracker) wait() time.Duration {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	remaining := t.nextAllowedAt.Sub(t.now())
+	if remaining < 0 {
+		return 0
+	}
+	return remaining
+}
+
+// rateLimitTransport is an http.RoundTripper that records Retry-After from any
+// 429 Too Many Requests responses observed on the wire, including ones
+// retryablehttp will subsequently retry.
+type rateLimitTransport struct {
+	inner   http.RoundTripper
+	tracker *rateLimitTracker
+}
+
+func (rt *rateLimitTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	resp, err := rt.inner.RoundTrip(req)
+	if err != nil || resp == nil {
+		return resp, err
+	}
+	if resp.StatusCode == http.StatusTooManyRequests {
+		if d, ok := parseRetryAfter(resp.Header.Get("Retry-After"), rt.tracker.now()); ok {
+			rt.tracker.record(d)
+		}
+	}
+	return resp, nil
+}
+
+// parseRetryAfter parses an HTTP Retry-After header value, which RFC 7231
+// defines as either delta-seconds or an HTTP-date, relative to `now`.
+func parseRetryAfter(value string, now time.Time) (time.Duration, bool) {
+	if value == "" {
+		return 0, false
+	}
+	if secs, err := strconv.Atoi(value); err == nil {
+		return time.Duration(secs) * time.Second, true
+	}
+	if t, err := http.ParseTime(value); err == nil {
+		return t.Sub(now), true
+	}
+	return 0, false
+}

--- a/internal/provider/ratelimit_test.go
+++ b/internal/provider/ratelimit_test.go
@@ -1,0 +1,179 @@
+package provider
+
+import (
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/michelangelomo/external-dns-desec-provider/internal/config"
+	"sigs.k8s.io/external-dns/endpoint"
+	"sigs.k8s.io/external-dns/plan"
+)
+
+func TestRateLimitTracker_RecordsRetryAfter(t *testing.T) {
+	now := time.Date(2026, 5, 19, 12, 0, 0, 0, time.UTC)
+	tr := &rateLimitTracker{now: func() time.Time { return now }}
+
+	tr.record(5 * time.Second)
+
+	if got := tr.wait(); got != 5*time.Second {
+		t.Errorf("wait() = %s, want 5s", got)
+	}
+}
+
+func TestRateLimitTracker_AllowsAfterExpiry(t *testing.T) {
+	cur := time.Date(2026, 5, 19, 12, 0, 0, 0, time.UTC)
+	tr := &rateLimitTracker{now: func() time.Time { return cur }}
+
+	tr.record(5 * time.Second)
+	cur = cur.Add(6 * time.Second)
+
+	if got := tr.wait(); got != 0 {
+		t.Errorf("wait() = %s, want 0", got)
+	}
+}
+
+func TestRateLimitTracker_DoesNotShrinkWindow(t *testing.T) {
+	cur := time.Date(2026, 5, 19, 12, 0, 0, 0, time.UTC)
+	tr := &rateLimitTracker{now: func() time.Time { return cur }}
+
+	tr.record(60 * time.Second)
+	tr.record(5 * time.Second) // a shorter retry-after must not shrink the window
+
+	if got := tr.wait(); got != 60*time.Second {
+		t.Errorf("wait() = %s, want 60s", got)
+	}
+}
+
+func TestRateLimitTracker_IgnoresNonPositive(t *testing.T) {
+	cur := time.Date(2026, 5, 19, 12, 0, 0, 0, time.UTC)
+	tr := &rateLimitTracker{now: func() time.Time { return cur }}
+
+	tr.record(0)
+	tr.record(-5 * time.Second)
+
+	if got := tr.wait(); got != 0 {
+		t.Errorf("wait() = %s, want 0", got)
+	}
+}
+
+func TestParseRetryAfter_Seconds(t *testing.T) {
+	d, ok := parseRetryAfter("120", time.Now())
+	if !ok || d != 120*time.Second {
+		t.Errorf("parseRetryAfter(\"120\") = (%s, %v), want (2m, true)", d, ok)
+	}
+}
+
+func TestParseRetryAfter_HTTPDate(t *testing.T) {
+	now := time.Date(2026, 5, 19, 12, 0, 0, 0, time.UTC)
+	target := now.Add(90 * time.Second)
+	value := target.Format(http.TimeFormat)
+
+	d, ok := parseRetryAfter(value, now)
+	if !ok {
+		t.Fatalf("parseRetryAfter(%q) returned ok=false", value)
+	}
+	if d < 89*time.Second || d > 91*time.Second {
+		t.Errorf("parseRetryAfter date duration = %s, want ~90s", d)
+	}
+}
+
+func TestParseRetryAfter_Invalid(t *testing.T) {
+	tests := []string{"", "garbage", "not-a-number"}
+	for _, v := range tests {
+		if _, ok := parseRetryAfter(v, time.Now()); ok {
+			t.Errorf("parseRetryAfter(%q) returned ok=true, want false", v)
+		}
+	}
+}
+
+func TestRateLimitTransport_CapturesRetryAfter(t *testing.T) {
+	var requests int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests++
+		w.Header().Set("Retry-After", "60")
+		w.WriteHeader(http.StatusTooManyRequests)
+	}))
+	defer server.Close()
+
+	tracker := newRateLimitTracker()
+	client := &http.Client{
+		Transport: &rateLimitTransport{inner: http.DefaultTransport, tracker: tracker},
+	}
+
+	req, _ := http.NewRequest(http.MethodGet, server.URL, nil)
+	resp, err := client.Do(req)
+	if err != nil {
+		t.Fatalf("Do: %v", err)
+	}
+	_ = resp.Body.Close()
+
+	if requests != 1 {
+		t.Errorf("expected 1 request, got %d", requests)
+	}
+	if d := tracker.wait(); d < 59*time.Second || d > 61*time.Second {
+		t.Errorf("tracker.wait() = %s, want ~60s", d)
+	}
+}
+
+func TestRateLimitTransport_IgnoresNon429(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Retry-After", "60") // present but irrelevant on 200
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	tracker := newRateLimitTracker()
+	client := &http.Client{
+		Transport: &rateLimitTransport{inner: http.DefaultTransport, tracker: tracker},
+	}
+
+	req, _ := http.NewRequest(http.MethodGet, server.URL, nil)
+	resp, err := client.Do(req)
+	if err != nil {
+		t.Fatalf("Do: %v", err)
+	}
+	_ = resp.Body.Close()
+
+	if d := tracker.wait(); d != 0 {
+		t.Errorf("tracker.wait() = %s after 200 OK, want 0", d)
+	}
+}
+
+func TestApplyChanges_ShortCircuitsDuringThrottle(t *testing.T) {
+	cfg := config.Config{
+		APIToken:      "test-token",
+		DomainFilters: []string{"example.com"},
+		DefaultTTL:    3600,
+	}
+	client, err := CreateDesecClient(cfg)
+	if err != nil {
+		t.Fatalf("CreateDesecClient: %v", err)
+	}
+
+	client.rateLimit.record(10 * time.Minute)
+
+	err = client.ApplyChanges(plan.Changes{
+		Create: []*endpoint.Endpoint{
+			{
+				DNSName:    "x.example.com",
+				RecordType: "A",
+				Targets:    endpoint.Targets{"192.0.2.1"},
+				RecordTTL:  3600,
+			},
+		},
+	})
+
+	if err == nil {
+		t.Fatal("expected RateLimitError, got nil")
+	}
+	var rle *RateLimitError
+	if !errors.As(err, &rle) {
+		t.Fatalf("expected *RateLimitError, got %T: %v", err, err)
+	}
+	if rle.RetryAfter < 9*time.Minute {
+		t.Errorf("RetryAfter = %s, want at least 9m", rle.RetryAfter)
+	}
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
 
 	"github.com/gorilla/mux"
@@ -106,6 +107,11 @@ func (webhook webhook) recordsHandler(w http.ResponseWriter, r *http.Request) {
 }
 
 func (webhook webhook) applyChangesHandler(w http.ResponseWriter, r *http.Request) {
+	if err := dumpRequestBodyAtDebug(r, "/records"); err != nil {
+		w.WriteHeader(http.StatusBadRequest)
+		return
+	}
+
 	var changes plan.Changes
 
 	err := json.NewDecoder(r.Body).Decode(&changes)
@@ -125,6 +131,11 @@ func (webhook webhook) applyChangesHandler(w http.ResponseWriter, r *http.Reques
 }
 
 func (webhook webhook) adjustEndpointsHandler(w http.ResponseWriter, r *http.Request) {
+	if err := dumpRequestBodyAtDebug(r, "/adjustendpoints"); err != nil {
+		w.WriteHeader(http.StatusBadRequest)
+		return
+	}
+
 	adjustedEndpoints := []*endpoint.Endpoint{}
 
 	err := json.NewDecoder(r.Body).Decode(&adjustedEndpoints)
@@ -147,4 +158,24 @@ func (webhook webhook) adjustEndpointsHandler(w http.ResponseWriter, r *http.Req
 		return
 	}
 	_, _ = w.Write(buf.Bytes())
+}
+
+// dumpRequestBodyAtDebug logs the full request body when debug-level logging
+// is enabled, then rewinds r.Body so the handler can decode it normally.
+// Used to capture the full plan.Changes payload (including UpdateOld, Labels,
+// and ProviderSpecific) that the summary log lines do not show. The body
+// read is skipped entirely at info level so production deployments pay no
+// extra cost; enable with WEBHOOK_LOGLEVEL=debug.
+func dumpRequestBodyAtDebug(r *http.Request, label string) error {
+	if !log.IsLevelEnabled(log.DebugLevel) {
+		return nil
+	}
+	body, err := io.ReadAll(r.Body)
+	if err != nil {
+		log.Errorf("failed to read %s body for debug log: %v", label, err)
+		return err
+	}
+	log.Debugf("POST %s body: %s", label, string(body))
+	r.Body = io.NopCloser(bytes.NewReader(body))
+	return nil
 }

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -367,6 +367,87 @@ func TestWebhookServerShutdown(t *testing.T) {
 	}
 }
 
+// TestApplyChangesHandler_DebugBodyDump verifies that with debug logging on,
+// the raw request body is written to the log so an operator can inspect
+// UpdateOld and other plan.Changes fields the summary log lines omit.
+func TestApplyChangesHandler_DebugBodyDump(t *testing.T) {
+	webhook := createTestWebhook()
+
+	body, err := json.Marshal(plan.Changes{
+		UpdateNew: []*endpoint.Endpoint{
+			{DNSName: "diag.example.com", RecordType: "TXT", Targets: endpoint.Targets{`"heritage=external-dns"`}, RecordTTL: 3600},
+		},
+	})
+	if err != nil {
+		t.Fatalf("Failed to marshal changes: %v", err)
+	}
+
+	var buf bytes.Buffer
+	prevLevel := log.GetLevel()
+	prevOut := log.StandardLogger().Out
+	log.SetLevel(log.DebugLevel)
+	log.SetOutput(&buf)
+	defer func() {
+		log.SetLevel(prevLevel)
+		log.SetOutput(prevOut)
+	}()
+
+	req := httptest.NewRequest("POST", "/records", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+
+	webhook.applyChangesHandler(w, req)
+
+	if w.Code != http.StatusNoContent {
+		t.Fatalf("Status code = %v, want %v (logs: %s)", w.Code, http.StatusNoContent, buf.String())
+	}
+	if !bytes.Contains(buf.Bytes(), []byte("POST /records body:")) {
+		t.Errorf("expected debug log to contain body dump prefix, got: %s", buf.String())
+	}
+	if !bytes.Contains(buf.Bytes(), []byte("diag.example.com")) {
+		t.Errorf("expected debug log to contain the request body, got: %s", buf.String())
+	}
+}
+
+// TestApplyChangesHandler_NoDebugDumpAtInfoLevel verifies that at info level
+// (the default) the handler does not log the body and still serves the
+// request correctly -- so the diagnostic flag is opt-in.
+func TestApplyChangesHandler_NoDebugDumpAtInfoLevel(t *testing.T) {
+	webhook := createTestWebhook()
+
+	body, err := json.Marshal(plan.Changes{
+		Create: []*endpoint.Endpoint{
+			{DNSName: "quiet.example.com", RecordType: "A", Targets: endpoint.Targets{"192.0.2.1"}, RecordTTL: 3600},
+		},
+	})
+	if err != nil {
+		t.Fatalf("Failed to marshal changes: %v", err)
+	}
+
+	var buf bytes.Buffer
+	prevLevel := log.GetLevel()
+	prevOut := log.StandardLogger().Out
+	log.SetLevel(log.InfoLevel)
+	log.SetOutput(&buf)
+	defer func() {
+		log.SetLevel(prevLevel)
+		log.SetOutput(prevOut)
+	}()
+
+	req := httptest.NewRequest("POST", "/records", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+
+	webhook.applyChangesHandler(w, req)
+
+	if w.Code != http.StatusNoContent {
+		t.Fatalf("Status code = %v, want %v", w.Code, http.StatusNoContent)
+	}
+	if bytes.Contains(buf.Bytes(), []byte("POST /records body:")) {
+		t.Errorf("info level should not emit body dump; got: %s", buf.String())
+	}
+}
+
 // Integration test with HTTP server
 func TestWebhookServerIntegration(t *testing.T) {
 	config := config.Config{


### PR DESCRIPTION
## fix(provider): strip trailing dot from /records DNSName

- fixes #18 

external-dns sources emit `Endpoint.DNSName` without a trailing dot. `convertRRSetToEndpoint` was appending one unconditionally, so `/records` returned the dotted form. The external-dns plan calculator compares dotted current state against dotless desired state, and the TXT registry treats that string mismatch as a stale companion record. It then set `providerSpecific` `txt/force-update=true` on every `UpdateOld` entry, which `plan.providerSpecificChanged()` promoted into an `Update`.

Tests:
- existing `convertRRSetToEndpoint` cases updated to assert dotless `DNSName` (including the "Apex with dotted domain" case that proves inbound domain strings with a trailing dot still get normalized)
- new `TestConvertRRSetToEndpoint_DNSNameHasNoTrailingDot` pins the invariant across subdomain, apex, deep subdomain, and dotted-domain input so a future refactor cannot silently reintroduce the loop

## chore(provider): Log POST body at debug level for plan.Changes diagnosis

Adds a single debug-gated body dump at the top of both `/records` and `/adjustendpoints` handlers.
The dump fires only when `WEBHOOK_LOGLEVEL=debug` is set; at info level (the default) the helper short-circuits before reading the body, so production deployments pay no cost. The motivation is that it was hard to debug the above problem with the only summary log line present.

## feat(provider): respect Retry-After to break the HTTP 429 reconcile loop

When deSEC returns `429 Too Many Requests`, the response carries a `Retry-After` header indicating how long the throttle window will remain active. Until now the webhook ignored that header at the client level: on the next reconcile (1m) external-dns would POST `/records` again and we'd immediately hit deSEC, extending the throttle window.

This change adds:

- `rateLimitTransport`: an `http.RoundTripper` that wraps the `http.Client` passed to `nrdcg/desec`. On any 429 response it parses `Retry-After` (delta-seconds or HTTP-date per RFC 7231) and records the deadline.

- `rateLimitTracker`: a goroutine-safe holder for the next-allowed-at timestamp. The window only ever extends, never shrinks, so a later 429 with a smaller `Retry-After` can't accidentally release us early.

- `ApplyChanges` short-circuit: at the top of `ApplyChanges`, if the tracker reports we're still inside the window, return a typed `RateLimitError` without hitting the API. external-dns still gets a 500 and will keep retrying, but our daily quota is preserved until the window legitimately expires.
The error type is modeled after the one proposed in the upstream draft PR #17 so the API stays consistent if that work eventually replaces `nrdcg/desec`.