### PR TITLE
Fix many, many things

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,9 +19,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version: "1.25"
       - name: golangci-lint
@@ -45,13 +45,13 @@ jobs:
             runner: ubuntu-24.04-arm
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Log into registry ${{ env.REGISTRY }}
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -59,7 +59,7 @@ jobs:
 
       - name: Build and push by digest
         id: build
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: .
           platforms: ${{ matrix.platform }}
@@ -76,7 +76,7 @@ jobs:
           touch "/tmp/digests/${digest#sha256:}"
 
       - name: Upload digest
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: digests-ci-${{ matrix.runner }}
           path: /tmp/digests/*
@@ -89,17 +89,17 @@ jobs:
     needs: docker
     steps:
       - name: Download digests
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           path: /tmp/digests
           pattern: digests-ci-*
           merge-multiple: true
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Log into registry ${{ env.REGISTRY }}
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,7 @@ name: CI
 on:
   pull_request:
     branches: [main]
+  workflow_dispatch:
 
 env:
   REGISTRY: ghcr.io

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -135,7 +135,7 @@ jobs:
           echo "digest=$DIGEST" >> "$GITHUB_OUTPUT"
 
       - name: Install cosign
-        uses: sigstore/cosign-installer@v4
+        uses: sigstore/cosign-installer@v4.0.0
         with:
           cosign-release: "v3.0.6"
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -137,7 +137,7 @@ jobs:
       - name: Install cosign
         uses: sigstore/cosign-installer@v4
         with:
-          cosign-release: "v2.2.4"
+          cosign-release: "v3.0.6"
 
       - name: Sign the published Docker image
         if: ${{ github.event_name != 'pull_request' }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,10 +45,10 @@ jobs:
           fi
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Log into registry ${{ env.REGISTRY }}
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -56,7 +56,7 @@ jobs:
 
       - name: Build and push by digest
         id: build
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: .
           platforms: ${{ matrix.platform }}
@@ -73,7 +73,7 @@ jobs:
           touch "/tmp/digests/${digest#sha256:}"
 
       - name: Upload digest
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: digests-release-${{ matrix.runner }}
           path: /tmp/digests/*
@@ -90,7 +90,7 @@ jobs:
       id-token: write
     steps:
       - name: Download digests
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           path: /tmp/digests
           pattern: digests-release-*
@@ -105,10 +105,10 @@ jobs:
           fi
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Log into registry ${{ env.REGISTRY }}
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -116,7 +116,7 @@ jobs:
 
       - name: Extract Docker metadata
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
@@ -135,7 +135,7 @@ jobs:
           echo "digest=$DIGEST" >> "$GITHUB_OUTPUT"
 
       - name: Install cosign
-        uses: sigstore/cosign-installer@v3
+        uses: sigstore/cosign-installer@v4
         with:
           cosign-release: "v2.2.4"
 
@@ -147,7 +147,7 @@ jobs:
         run: echo "${TAGS}" | xargs -I {} cosign sign --yes {}@${DIGEST}
 
       - name: Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         if: github.ref_type == 'tag'
         with:
           generate_release_notes: true

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.25
 require (
 	github.com/gorilla/mux v1.8.1
 	github.com/kelseyhightower/envconfig v1.4.0
-	github.com/nrdcg/desec v0.11.1
+	github.com/nrdcg/desec v0.11.2
 	github.com/sirupsen/logrus v1.9.4
 	golang.org/x/net v0.49.0
 	sigs.k8s.io/external-dns v0.20.0

--- a/go.sum
+++ b/go.sum
@@ -73,6 +73,8 @@ github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 h1:C3w9PqII01/Oq
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822/go.mod h1:+n7T8mK8HuQTcFwEeznm/DIxMOiR9yIdICNftLE1DvQ=
 github.com/nrdcg/desec v0.11.1 h1:ilpKmCr4gGsLcyq3RHfHNmlRzm9fzT2XbWxoVaUCS0s=
 github.com/nrdcg/desec v0.11.1/go.mod h1:2LuxHlOcwML/7cntu0eimONmA1U+ZxFDAonoSXr4igQ=
+github.com/nrdcg/desec v0.11.2 h1:zPttKdQFzmlXMSkiuKnb34G7LkROdmRyL9SidYXIm4k=
+github.com/nrdcg/desec v0.11.2/go.mod h1:2LuxHlOcwML/7cntu0eimONmA1U+ZxFDAonoSXr4igQ=
 github.com/onsi/ginkgo v1.16.5 h1:8xi0RTUf59SOSfEtZMvwTvXYMzG4gV23XVHOZiXNtnE=
 github.com/onsi/ginkgo/v2 v2.22.0 h1:Yed107/8DjTr0lKCNt7Dn8yQ6ybuDRQoMGrNFKzMfHg=
 github.com/onsi/ginkgo/v2 v2.22.0/go.mod h1:7Du3c42kxCUegi0IImZ1wUQzMBVecgIHjR1C+NkhLQo=

--- a/internal/provider/desec.go
+++ b/internal/provider/desec.go
@@ -308,14 +308,19 @@ func convertRRSetToEndpoint(rrset *desec.RRSet, domain string) *endpoint.Endpoin
 		return nil
 	}
 
-	// Compose DNSName from subname and domain
+	// Compose DNSName from subname and domain. external-dns sources emit
+	// DNSName without a trailing dot, and external-dns's TXT registry
+	// matches companion records by exact-string DNSName -- if /records
+	// returns a dotted form, the registry sets providerSpecific
+	// txt/force-update=true on every reconcile and the plan calculator
+	// emits a no-op Update for every record.
 	var dnsName string
 	if rrset.SubName == "" {
 		dnsName = domain
 	} else {
 		dnsName = rrset.SubName + "." + domain
 	}
-	dnsName = strings.TrimSuffix(dnsName, ".") + "."
+	dnsName = strings.TrimSuffix(dnsName, ".")
 
 	targets := make(endpoint.Targets, len(rrset.Records))
 	copy(targets, rrset.Records)

--- a/internal/provider/desec.go
+++ b/internal/provider/desec.go
@@ -2,7 +2,9 @@ package provider
 
 import (
 	"context"
+	"net/http"
 	"strings"
+	"time"
 
 	"github.com/michelangelomo/external-dns-desec-provider/internal/config"
 	"github.com/nrdcg/desec"
@@ -18,6 +20,7 @@ type DesecClient struct {
 	dryRun        bool
 	defaultTTL    int
 	domainFilters []string
+	rateLimit     *rateLimitTracker
 }
 
 const (
@@ -30,13 +33,26 @@ func CreateDesecClient(config config.Config) (*DesecClient, error) {
 		config.DefaultTTL = minimumTTL
 	}
 
+	tracker := newRateLimitTracker()
+	httpClient := &http.Client{
+		Timeout: 10 * time.Second,
+		Transport: &rateLimitTransport{
+			inner:   http.DefaultTransport,
+			tracker: tracker,
+		},
+	}
+
 	ctx := context.Background()
 	client := &DesecClient{
-		client:        desec.New(config.APIToken, desec.ClientOptions{RetryMax: 2}),
+		client: desec.New(config.APIToken, desec.ClientOptions{
+			RetryMax:   2,
+			HTTPClient: httpClient,
+		}),
 		ctx:           ctx,
 		dryRun:        config.DryRun,
 		defaultTTL:    config.DefaultTTL,
 		domainFilters: config.DomainFilters,
+		rateLimit:     tracker,
 	}
 	return client, nil
 }
@@ -69,6 +85,11 @@ func (d *DesecClient) GetEndpoints(domain string) ([]*endpoint.Endpoint, error) 
 }
 
 func (d *DesecClient) ApplyChanges(changes plan.Changes) error {
+	if remaining := d.rateLimit.wait(); remaining > 0 {
+		log.Warnf("deSEC rate limit active; skipping ApplyChanges for %s to preserve daily quota", remaining)
+		return &RateLimitError{RetryAfter: remaining}
+	}
+
 	log.Debugf("applying changes: %d creates, %d updates, %d deletes",
 		len(changes.Create), len(changes.UpdateNew), len(changes.Delete))
 

--- a/internal/provider/desec.go
+++ b/internal/provider/desec.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/http"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/michelangelomo/external-dns-desec-provider/internal/config"
@@ -21,10 +22,24 @@ type DesecClient struct {
 	defaultTTL    int
 	domainFilters []string
 	rateLimit     *rateLimitTracker
+
+	cacheMu sync.Mutex
+	cache   map[string]cachedEndpoints
+}
+
+type cachedEndpoints struct {
+	endpoints []*endpoint.Endpoint
+	fetchedAt time.Time
 }
 
 const (
 	minimumTTL = 3600 // Minimum TTL for desec is 3600 seconds
+
+	// maxCacheStaleness caps how old a last-known-good record set may be before
+	// it is no longer served during a throttle window. Past it we prefer a 500
+	// (retried next interval) over feeding external-dns a stale zone under
+	// --policy=sync, which could delete records that in fact still exist.
+	maxCacheStaleness = 24 * time.Hour
 )
 
 // retryableLogger adapts logrus to retryablehttp.LeveledLogger so the retry
@@ -75,6 +90,7 @@ func CreateDesecClient(config config.Config) (*DesecClient, error) {
 		defaultTTL:    config.DefaultTTL,
 		domainFilters: config.DomainFilters,
 		rateLimit:     tracker,
+		cache:         make(map[string]cachedEndpoints),
 	}
 	return client, nil
 }
@@ -118,7 +134,46 @@ func (d *DesecClient) GetEndpoints(ctx context.Context, domain string) ([]*endpo
 			rrset.SubName, rrset.Type, ep.DNSName, ep.RecordType, ep.Targets, ep.RecordTTL)
 		endpoints = append(endpoints, ep)
 	}
+
+	// Remember this successful fetch as last-known-good so a later throttle
+	// window can be answered from cache instead of a 500.
+	d.cacheMu.Lock()
+	d.cache[domain] = cachedEndpoints{endpoints: endpoints, fetchedAt: d.rateLimit.now()}
+	d.cacheMu.Unlock()
+
 	return endpoints, nil
+}
+
+// Throttled reports whether a deSEC throttle window observed from a prior 429 is
+// still open. Handlers consult it to decide whether serving stale cached records
+// is warranted.
+func (d *DesecClient) Throttled() bool {
+	return d.rateLimit.wait() > 0
+}
+
+// CachedEndpoints returns last-known-good endpoints for every requested domain,
+// but only all-or-nothing: if any domain has never been fetched successfully or
+// its cache is older than maxCacheStaleness, it returns ok=false. Serving a
+// partial set under --policy=sync would make external-dns recreate the missing
+// domain's records, so a gap must fall through to a 500 instead.
+func (d *DesecClient) CachedEndpoints(domains []string) ([]*endpoint.Endpoint, bool) {
+	d.cacheMu.Lock()
+	defer d.cacheMu.Unlock()
+
+	now := d.rateLimit.now()
+	endpoints := []*endpoint.Endpoint{}
+	for _, domain := range domains {
+		entry, ok := d.cache[domain]
+		if !ok {
+			return nil, false
+		}
+		if now.Sub(entry.fetchedAt) > maxCacheStaleness {
+			log.Warnf("cached records for %s are older than %s; not serving stale zone", domain, maxCacheStaleness)
+			return nil, false
+		}
+		endpoints = append(endpoints, entry.endpoints...)
+	}
+	return endpoints, true
 }
 
 func (d *DesecClient) ApplyChanges(ctx context.Context, changes plan.Changes) error {

--- a/internal/provider/desec.go
+++ b/internal/provider/desec.go
@@ -121,12 +121,12 @@ func (d *DesecClient) GetEndpoints(ctx context.Context, domain string) ([]*endpo
 		return nil, &RateLimitError{RetryAfter: remaining}
 	}
 
-	log.Debugf("fetching records for domain %s", domain)
+	log.Infof("fetching records for domain %s", domain)
 	rrsets, err := d.client.Records.GetAll(ctx, domain, nil)
 	if err != nil {
 		return nil, err
 	}
-	log.Debugf("fetched %d rrsets for domain %s", len(rrsets), domain)
+	log.Infof("fetched %d rrsets for domain %s", len(rrsets), domain)
 
 	endpoints := make([]*endpoint.Endpoint, 0, len(rrsets))
 	for _, rrset := range rrsets {

--- a/internal/provider/desec.go
+++ b/internal/provider/desec.go
@@ -2,6 +2,7 @@ package provider
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 	"strings"
 	"time"
@@ -16,7 +17,6 @@ import (
 
 type DesecClient struct {
 	client        *desec.Client
-	ctx           context.Context
 	dryRun        bool
 	defaultTTL    int
 	domainFilters []string
@@ -26,6 +26,27 @@ type DesecClient struct {
 const (
 	minimumTTL = 3600 // Minimum TTL for desec is 3600 seconds
 )
+
+// retryableLogger adapts logrus to retryablehttp.LeveledLogger so the retry
+// client's status codes and wait durations surface in the app's log stream.
+type retryableLogger struct{}
+
+func (retryableLogger) Error(msg string, kv ...any) { log.WithFields(kvFields(kv)).Error(msg) }
+func (retryableLogger) Warn(msg string, kv ...any)  { log.WithFields(kvFields(kv)).Warn(msg) }
+func (retryableLogger) Info(msg string, kv ...any)  { log.WithFields(kvFields(kv)).Info(msg) }
+func (retryableLogger) Debug(msg string, kv ...any) { log.WithFields(kvFields(kv)).Debug(msg) }
+
+func kvFields(kv []any) log.Fields {
+	fields := log.Fields{}
+	for i := 0; i+1 < len(kv); i += 2 {
+		key, ok := kv[i].(string)
+		if !ok {
+			key = fmt.Sprintf("%v", kv[i])
+		}
+		fields[key] = kv[i+1]
+	}
+	return fields
+}
 
 func CreateDesecClient(config config.Config) (*DesecClient, error) {
 	if config.DefaultTTL < minimumTTL {
@@ -42,13 +63,14 @@ func CreateDesecClient(config config.Config) (*DesecClient, error) {
 		},
 	}
 
-	ctx := context.Background()
 	client := &DesecClient{
 		client: desec.New(config.APIToken, desec.ClientOptions{
 			RetryMax:   2,
 			HTTPClient: httpClient,
+			// Without a logger retryablehttp swallows the 429 and its retry
+			// wait, which is how the ~12.5h sleep was invisible in the logs.
+			Logger: retryableLogger{},
 		}),
-		ctx:           ctx,
 		dryRun:        config.DryRun,
 		defaultTTL:    config.DefaultTTL,
 		domainFilters: config.DomainFilters,
@@ -57,18 +79,33 @@ func CreateDesecClient(config config.Config) (*DesecClient, error) {
 	return client, nil
 }
 
-func (d *DesecClient) GetDomains() ([]desec.Domain, error) {
-	return d.client.Domains.GetAll(d.ctx)
+func (d *DesecClient) GetDomains(ctx context.Context) ([]desec.Domain, error) {
+	return d.client.Domains.GetAll(ctx)
 }
 
-func (d *DesecClient) GetRecords(domain string) ([]desec.RRSet, error) {
-	return d.client.Records.GetAll(d.ctx, domain, nil)
+func (d *DesecClient) GetRecords(ctx context.Context, domain string) ([]desec.RRSet, error) {
+	if remaining := d.rateLimit.wait(); remaining > 0 {
+		return nil, &RateLimitError{RetryAfter: remaining}
+	}
+	return d.client.Records.GetAll(ctx, domain, nil)
 }
 
 // GetEndpoints fetches all RRSets for a domain and converts them to external-dns Endpoints.
-func (d *DesecClient) GetEndpoints(domain string) ([]*endpoint.Endpoint, error) {
+// The caller's context is threaded through to the deSEC call so external-dns's
+// webhook read timeout can interrupt a request stuck retrying a 429 -- the
+// deSEC library sleeps the raw Retry-After (up to ~12.5h) between retries and
+// only wakes on ctx cancellation or the timer.
+func (d *DesecClient) GetEndpoints(ctx context.Context, domain string) ([]*endpoint.Endpoint, error) {
+	// Skip the API entirely while a throttle window observed from a prior 429
+	// is still open: hitting deSEC again would only burn more of the daily
+	// quota and return another long Retry-After.
+	if remaining := d.rateLimit.wait(); remaining > 0 {
+		log.Warnf("deSEC rate limit active; skipping /records fetch for %s (retry after %s)", domain, remaining)
+		return nil, &RateLimitError{RetryAfter: remaining}
+	}
+
 	log.Debugf("fetching records for domain %s", domain)
-	rrsets, err := d.client.Records.GetAll(d.ctx, domain, nil)
+	rrsets, err := d.client.Records.GetAll(ctx, domain, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -84,7 +121,7 @@ func (d *DesecClient) GetEndpoints(domain string) ([]*endpoint.Endpoint, error) 
 	return endpoints, nil
 }
 
-func (d *DesecClient) ApplyChanges(changes plan.Changes) error {
+func (d *DesecClient) ApplyChanges(ctx context.Context, changes plan.Changes) error {
 	if remaining := d.rateLimit.wait(); remaining > 0 {
 		log.Warnf("deSEC rate limit active; skipping ApplyChanges for %s to preserve daily quota", remaining)
 		return &RateLimitError{RetryAfter: remaining}
@@ -156,7 +193,7 @@ func (d *DesecClient) ApplyChanges(changes plan.Changes) error {
 
 		log.Debugf("applying %d changes for domain %s (%d create, %d update, %d delete): %v",
 			len(toApply), domain, len(bc.create), len(bc.updateNew), len(bc.delete), toApply)
-		_, err := d.client.Records.BulkUpdate(d.ctx, desec.FullResource, domain, toApply)
+		_, err := d.client.Records.BulkUpdate(ctx, desec.FullResource, domain, toApply)
 		if err != nil {
 			log.Errorf("failed to apply changes for domain %s: %v, payload: %v", domain, err, toApply)
 			return err

--- a/internal/provider/desec.go
+++ b/internal/provider/desec.go
@@ -100,11 +100,17 @@ func (d *DesecClient) GetDomains(ctx context.Context) ([]desec.Domain, error) {
 	return d.client.Domains.GetAll(ctx)
 }
 
-func (d *DesecClient) GetRecords(ctx context.Context, domain string) ([]desec.RRSet, error) {
-	if remaining := d.rateLimit.wait(); remaining > 0 {
-		return nil, &RateLimitError{RetryAfter: remaining}
+// checkThrottle returns a *RateLimitError while a throttle window observed from
+// a prior 429 is still open, so a call can skip the API entirely: hitting deSEC
+// again would only burn more of the daily quota and return another long
+// Retry-After. op names the skipped operation for the log line.
+func (d *DesecClient) checkThrottle(op string) *RateLimitError {
+	remaining := d.rateLimit.wait()
+	if remaining <= 0 {
+		return nil
 	}
-	return d.client.Records.GetAll(ctx, domain, nil)
+	log.Warnf("deSEC rate limit active; skipping %s (retry after %s)", op, remaining)
+	return &RateLimitError{RetryAfter: remaining}
 }
 
 // GetEndpoints fetches all RRSets for a domain and converts them to external-dns Endpoints.
@@ -113,12 +119,8 @@ func (d *DesecClient) GetRecords(ctx context.Context, domain string) ([]desec.RR
 // deSEC library sleeps the raw Retry-After (up to ~12.5h) between retries and
 // only wakes on ctx cancellation or the timer.
 func (d *DesecClient) GetEndpoints(ctx context.Context, domain string) ([]*endpoint.Endpoint, error) {
-	// Skip the API entirely while a throttle window observed from a prior 429
-	// is still open: hitting deSEC again would only burn more of the daily
-	// quota and return another long Retry-After.
-	if remaining := d.rateLimit.wait(); remaining > 0 {
-		log.Warnf("deSEC rate limit active; skipping /records fetch for %s (retry after %s)", domain, remaining)
-		return nil, &RateLimitError{RetryAfter: remaining}
+	if rle := d.checkThrottle("/records fetch for " + domain); rle != nil {
+		return nil, rle
 	}
 
 	log.Infof("fetching records for domain %s", domain)
@@ -178,9 +180,8 @@ func (d *DesecClient) CachedEndpoints(domains []string) ([]*endpoint.Endpoint, b
 }
 
 func (d *DesecClient) ApplyChanges(ctx context.Context, changes plan.Changes) error {
-	if remaining := d.rateLimit.wait(); remaining > 0 {
-		log.Warnf("deSEC rate limit active; skipping ApplyChanges for %s to preserve daily quota", remaining)
-		return &RateLimitError{RetryAfter: remaining}
+	if rle := d.checkThrottle("ApplyChanges"); rle != nil {
+		return rle
 	}
 
 	log.Debugf("applying changes: %d creates, %d updates, %d deletes",

--- a/internal/provider/desec.go
+++ b/internal/provider/desec.go
@@ -73,8 +73,9 @@ func CreateDesecClient(config config.Config) (*DesecClient, error) {
 	httpClient := &http.Client{
 		Timeout: 10 * time.Second,
 		Transport: &rateLimitTransport{
-			inner:   http.DefaultTransport,
-			tracker: tracker,
+			inner:     http.DefaultTransport,
+			tracker:   tracker,
+			proactive: newProactiveLimiter(tracker.now),
 		},
 	}
 

--- a/internal/provider/desec.go
+++ b/internal/provider/desec.go
@@ -93,64 +93,75 @@ func (d *DesecClient) ApplyChanges(changes plan.Changes) error {
 	log.Debugf("applying changes: %d creates, %d updates, %d deletes",
 		len(changes.Create), len(changes.UpdateNew), len(changes.Delete))
 
-	// Create new records
+	// deSEC bulk operations are atomic and validate the *resulting* zone
+	// state, so we merge creates, updates, and deletes for each domain into a
+	// single PUT (desec.FullResource). This avoids the non-atomic Create-then-
+	// Delete ordering that breaks record-type changes: a retype reaches us as
+	// Delete(old A) + Create(new CNAME) at the same subname, and posting the
+	// CNAME while the A still exists is rejected by deSEC (CNAME may not
+	// coexist with other types). Encoding the deletion as records:[] in the
+	// same request lets deSEC validate the final state (A gone, CNAME present)
+	// and accept it. BulkUpdate(FullResource, ...) only touches the rrsets in
+	// the request, so unrelated records are untouched.
+	type bulkChanges struct {
+		create    []desec.RRSet
+		updateNew []desec.RRSet
+		delete    []desec.RRSet
+	}
+	merged := make(map[string]*bulkChanges)
+
+	get := func(domain string) *bulkChanges {
+		bc := merged[domain]
+		if bc == nil {
+			bc = &bulkChanges{}
+			merged[domain] = bc
+		}
+		return bc
+	}
+
 	for domain, endpoints := range d.mapEndpointsByHostname(changes.Create) {
-		var toCreate []desec.RRSet
-		for _, endpoint := range endpoints {
-			toCreate = append(toCreate, *convertEndpointToRRSet(endpoint, domain, d.defaultTTL))
-		}
-
-		if d.dryRun {
-			log.Infof("dryrun: would create %d records for domain %s: %v", len(toCreate), domain, toCreate)
-		} else {
-			log.Debugf("creating %d records for domain %s: %v", len(toCreate), domain, toCreate)
-			_, err := d.client.Records.BulkCreate(d.ctx, domain, toCreate)
-			if err != nil {
-				log.Errorf("failed to create records for domain %s: %v, payload: %v", domain, err, toCreate)
-				return err
-			}
-			log.Debugf("successfully created %d records for domain %s", len(toCreate), domain)
+		bc := get(domain)
+		for _, ep := range endpoints {
+			bc.create = append(bc.create, *convertEndpointToRRSet(ep, domain, d.defaultTTL))
 		}
 	}
-
-	// Update existing records
 	for domain, endpoints := range d.mapEndpointsByHostname(changes.UpdateNew) {
-		var toUpdate []desec.RRSet
-		for _, endpoint := range endpoints {
-			toUpdate = append(toUpdate, *convertEndpointToRRSet(endpoint, domain, d.defaultTTL))
+		bc := get(domain)
+		for _, ep := range endpoints {
+			bc.updateNew = append(bc.updateNew, *convertEndpointToRRSet(ep, domain, d.defaultTTL))
 		}
-
-		if d.dryRun {
-			log.Infof("dryrun: would update %d records for domain %s: %v", len(toUpdate), domain, toUpdate)
-		} else {
-			log.Debugf("updating %d records for domain %s: %v", len(toUpdate), domain, toUpdate)
-			_, err := d.client.Records.BulkUpdate(d.ctx, desec.FullResource, domain, toUpdate)
-			if err != nil {
-				log.Errorf("failed to update records for domain %s: %v, payload: %v", domain, err, toUpdate)
-				return err
-			}
-			log.Debugf("successfully updated %d records for domain %s", len(toUpdate), domain)
+	}
+	for domain, endpoints := range d.mapEndpointsByHostname(changes.Delete) {
+		bc := get(domain)
+		for _, ep := range endpoints {
+			rrset := *convertEndpointToRRSet(ep, domain, d.defaultTTL)
+			// Encode deletion as an empty record set so the bulk PUT removes
+			// it while validating the final zone state.
+			rrset.Records = []string{}
+			bc.delete = append(bc.delete, rrset)
 		}
 	}
 
-	// Delete records
-	for domain, endpoints := range d.mapEndpointsByHostname(changes.Delete) {
-		var toDelete []desec.RRSet
-		for _, endpoint := range endpoints {
-			toDelete = append(toDelete, *convertEndpointToRRSet(endpoint, domain, d.defaultTTL))
-		}
+	for domain, bc := range merged {
+		toApply := make([]desec.RRSet, 0, len(bc.create)+len(bc.updateNew)+len(bc.delete))
+		toApply = append(toApply, bc.create...)
+		toApply = append(toApply, bc.updateNew...)
+		toApply = append(toApply, bc.delete...)
 
 		if d.dryRun {
-			log.Infof("dryrun: would delete %d records for domain %s: %v", len(toDelete), domain, toDelete)
-		} else {
-			log.Debugf("deleting %d records for domain %s: %v", len(toDelete), domain, toDelete)
-			err := d.client.Records.BulkDelete(d.ctx, domain, toDelete)
-			if err != nil {
-				log.Errorf("failed to delete records for domain %s: %v, payload: %v", domain, err, toDelete)
-				return err
-			}
-			log.Debugf("successfully deleted %d records for domain %s", len(toDelete), domain)
+			log.Infof("dryrun: would apply %d changes for domain %s (%d create, %d update, %d delete): %v",
+				len(toApply), domain, len(bc.create), len(bc.updateNew), len(bc.delete), toApply)
+			continue
 		}
+
+		log.Debugf("applying %d changes for domain %s (%d create, %d update, %d delete): %v",
+			len(toApply), domain, len(bc.create), len(bc.updateNew), len(bc.delete), toApply)
+		_, err := d.client.Records.BulkUpdate(d.ctx, desec.FullResource, domain, toApply)
+		if err != nil {
+			log.Errorf("failed to apply changes for domain %s: %v, payload: %v", domain, err, toApply)
+			return err
+		}
+		log.Debugf("successfully applied %d changes for domain %s", len(toApply), domain)
 	}
 
 	return nil

--- a/internal/provider/desec_apply_test.go
+++ b/internal/provider/desec_apply_test.go
@@ -1,6 +1,7 @@
 package provider
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -209,7 +210,7 @@ func TestDesecMock_RejectsCNAMEOverExistingA(t *testing.T) {
 	srv := m.server(t)
 	client := newTestClient(t, srv)
 
-	_, err := client.client.Records.BulkCreate(client.ctx, "example.com", []desec.RRSet{
+	_, err := client.client.Records.BulkCreate(context.Background(), "example.com", []desec.RRSet{
 		{SubName: "foo", Type: "CNAME", Records: []string{"bar.example."}, TTL: 3600},
 	})
 	if err == nil {
@@ -246,7 +247,7 @@ func TestApplyChanges_RetypeAtoCNAME(t *testing.T) {
 		},
 	}
 
-	err := client.ApplyChanges(changes)
+	err := client.ApplyChanges(context.Background(), changes)
 	if err != nil {
 		t.Fatalf("ApplyChanges(retype A->CNAME) must succeed after the atomic-bulk fix, got: %v", err)
 	}
@@ -276,7 +277,7 @@ func TestApplyChanges_CombinesUpdateAndCreateInOneRequest(t *testing.T) {
 		},
 	}
 
-	err := client.ApplyChanges(changes)
+	err := client.ApplyChanges(context.Background(), changes)
 	if err != nil {
 		t.Fatalf("ApplyChanges(update+create) returned error: %v", err)
 	}
@@ -317,7 +318,7 @@ func TestApplyChanges_DryRunMakesNoRequests(t *testing.T) {
 		},
 	}
 
-	if err := client.ApplyChanges(changes); err != nil {
+	if err := client.ApplyChanges(context.Background(), changes); err != nil {
 		t.Fatalf("dry-run ApplyChanges returned error: %v", err)
 	}
 

--- a/internal/provider/desec_apply_test.go
+++ b/internal/provider/desec_apply_test.go
@@ -1,0 +1,330 @@
+package provider
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/michelangelomo/external-dns-desec-provider/internal/config"
+	"github.com/nrdcg/desec"
+	"sigs.k8s.io/external-dns/endpoint"
+	"sigs.k8s.io/external-dns/plan"
+)
+
+// desecMock is an in-memory stand-in for the deSEC /rrsets/ API that enforces
+// the two real constraints exercised by the atomic-bulk-apply fix:
+//   - POST /rrsets/ (bulk create) only accepts brand-new rrsets, and
+//   - a CNAME may not coexist with any other type at the same subname.
+//
+// Bulk operations validate the *resulting* zone state and are atomic: either
+// all rrsets in the request are applied or none are (matching deSEC's
+// documented bulk semantics).
+type desecMock struct {
+	mu sync.Mutex
+	// zone keys an rrset by "subname|type"; value is its records.
+	zone map[string][]string
+	// requestCount counts mutating bulk requests (POST/PUT/PATCH) served.
+	requestCount int
+}
+
+func newDesecMock() *desecMock {
+	return &desecMock{zone: make(map[string][]string)}
+}
+
+func zoneKey(subname, typ string) string { return subname + "|" + typ }
+
+// seed inserts a record directly, bypassing constraint checks.
+func (m *desecMock) seed(subname, typ string, records ...string) {
+	m.zone[zoneKey(subname, typ)] = records
+}
+
+// has reports whether an rrset exists for the given subname/type.
+func (m *desecMock) has(subname, typ string) bool {
+	_, ok := m.zone[zoneKey(subname, typ)]
+	return ok
+}
+
+// subnameTypes returns the set of record types present at a subname.
+func (m *desecMock) subnameTypes() map[string]map[string]bool {
+	out := make(map[string]map[string]bool)
+	for k := range m.zone {
+		parts := strings.SplitN(k, "|", 2)
+		sub, typ := parts[0], parts[1]
+		if out[sub] == nil {
+			out[sub] = make(map[string]bool)
+		}
+		out[sub][typ] = true
+	}
+	return out
+}
+
+// desec-shaped 400 body: a JSON array of per-rrset error objects.
+func writeDesecError(w http.ResponseWriter, detail string) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusBadRequest)
+	_ = json.NewEncoder(w).Encode([]map[string]any{
+		{"non_field_errors": []string{detail}},
+	})
+}
+
+func (m *desecMock) server(t *testing.T) *httptest.Server {
+	t.Helper()
+	mux := http.NewServeMux()
+	// Path: /domains/<domain>/rrsets/
+	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		if !strings.HasSuffix(r.URL.Path, "/rrsets/") {
+			http.Error(w, "not found", http.StatusNotFound)
+			return
+		}
+
+		var rrsets []desec.RRSet
+		if err := json.NewDecoder(r.Body).Decode(&rrsets); err != nil {
+			http.Error(w, "bad json", http.StatusBadRequest)
+			return
+		}
+
+		m.mu.Lock()
+		defer m.mu.Unlock()
+
+		switch r.Method {
+		case http.MethodPost:
+			m.requestCount++
+			// Create-only: reject if any rrset already exists, then validate
+			// the resulting state. Apply atomically.
+			next := m.clone()
+			for _, rr := range rrsets {
+				if m.has(rr.SubName, rr.Type) {
+					writeDesecError(w, fmt.Sprintf("RRset %q/%q already exists.", rr.SubName, rr.Type))
+					return
+				}
+				next[zoneKey(rr.SubName, rr.Type)] = rr.Records
+			}
+			if detail, ok := validateZone(next); !ok {
+				writeDesecError(w, detail)
+				return
+			}
+			m.zone = next
+			w.WriteHeader(http.StatusCreated)
+			_ = json.NewEncoder(w).Encode(rrsets)
+
+		case http.MethodPut, http.MethodPatch:
+			m.requestCount++
+			// Upsert; records:[] deletes. Validate resulting state atomically.
+			next := m.clone()
+			for _, rr := range rrsets {
+				if len(rr.Records) == 0 {
+					delete(next, zoneKey(rr.SubName, rr.Type))
+					continue
+				}
+				next[zoneKey(rr.SubName, rr.Type)] = rr.Records
+			}
+			if detail, ok := validateZone(next); !ok {
+				writeDesecError(w, detail)
+				return
+			}
+			m.zone = next
+			w.WriteHeader(http.StatusOK)
+			out := make([]desec.RRSet, 0)
+			for _, rr := range rrsets {
+				if len(rr.Records) > 0 {
+					out = append(out, rr)
+				}
+			}
+			_ = json.NewEncoder(w).Encode(out)
+
+		default:
+			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		}
+	})
+
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+func (m *desecMock) clone() map[string][]string {
+	out := make(map[string][]string, len(m.zone))
+	for k, v := range m.zone {
+		cp := make([]string, len(v))
+		copy(cp, v)
+		out[k] = cp
+	}
+	return out
+}
+
+// validateZone enforces the deSEC CNAME-coexistence rule against a candidate
+// final zone state: a CNAME may not share a subname with any other type.
+func validateZone(zone map[string][]string) (string, bool) {
+	types := make(map[string]map[string]bool)
+	for k := range zone {
+		parts := strings.SplitN(k, "|", 2)
+		sub, typ := parts[0], parts[1]
+		if types[sub] == nil {
+			types[sub] = make(map[string]bool)
+		}
+		types[sub][typ] = true
+	}
+	for sub, ts := range types {
+		if ts["CNAME"] && len(ts) > 1 {
+			var other string
+			for t := range ts {
+				if t != "CNAME" {
+					other = t
+					break
+				}
+			}
+			return fmt.Sprintf("RRset with conflicting type present at same subname: %s (%s). (No other RRsets are allowed alongside CNAME.)", sub, other), false
+		}
+	}
+	return "", true
+}
+
+// newTestClient builds a DesecClient wired to the mock server's base URL.
+func newTestClient(t *testing.T, srv *httptest.Server) *DesecClient {
+	t.Helper()
+	cfg := config.Config{
+		APIToken:      "test-token",
+		DomainFilters: []string{"example.com"},
+		DryRun:        false,
+		DefaultTTL:    3600,
+	}
+	client, err := CreateDesecClient(cfg)
+	if err != nil {
+		t.Fatalf("CreateDesecClient: %v", err)
+	}
+	// Point the underlying nrdcg/desec client at the test server.
+	client.client.BaseURL = srv.URL + "/"
+	return client
+}
+
+// Test 1 (constraint pin): a lone bulk-create of a CNAME where an A already
+// exists is rejected by the mock with a deSEC-style 400. Documents the rule.
+func TestDesecMock_RejectsCNAMEOverExistingA(t *testing.T) {
+	m := newDesecMock()
+	m.seed("foo", "A", "1.2.3.4")
+	srv := m.server(t)
+	client := newTestClient(t, srv)
+
+	_, err := client.client.Records.BulkCreate(client.ctx, "example.com", []desec.RRSet{
+		{SubName: "foo", Type: "CNAME", Records: []string{"bar.example."}, TTL: 3600},
+	})
+	if err == nil {
+		t.Fatal("expected mock to reject CNAME-over-A bulk create, got nil error")
+	}
+	if !strings.Contains(err.Error(), "No other RRsets are allowed alongside CNAME") {
+		t.Errorf("expected deSEC CNAME-coexistence error, got: %v", err)
+	}
+	// Zone must be unchanged (atomic reject).
+	if m.has("foo", "CNAME") {
+		t.Error("CNAME must not have been created after rejection")
+	}
+	if !m.has("foo", "A") {
+		t.Error("pre-existing A must remain after rejection")
+	}
+}
+
+// Test 2 (repro -> fix): an A->CNAME retype reaches the provider as
+// Delete(old A) + Create(new CNAME) at the same subname. Against the current
+// code (Create-first POST) the mock 400s. After the fix it must succeed and
+// leave only the CNAME.
+func TestApplyChanges_RetypeAtoCNAME(t *testing.T) {
+	m := newDesecMock()
+	m.seed("foo", "A", "1.2.3.4")
+	srv := m.server(t)
+	client := newTestClient(t, srv)
+
+	changes := plan.Changes{
+		Create: []*endpoint.Endpoint{
+			{DNSName: "foo.example.com", RecordType: "CNAME", Targets: endpoint.Targets{"bar.example."}, RecordTTL: 3600},
+		},
+		Delete: []*endpoint.Endpoint{
+			{DNSName: "foo.example.com", RecordType: "A", Targets: endpoint.Targets{"1.2.3.4"}, RecordTTL: 3600},
+		},
+	}
+
+	err := client.ApplyChanges(changes)
+	if err != nil {
+		t.Fatalf("ApplyChanges(retype A->CNAME) must succeed after the atomic-bulk fix, got: %v", err)
+	}
+
+	if m.has("foo", "A") {
+		t.Error("old A record must be gone after retype")
+	}
+	if !m.has("foo", "CNAME") {
+		t.Error("new CNAME record must exist after retype")
+	}
+}
+
+// Test 3 (combine update+create): an UpdateNew plus a separate Create for the
+// same domain must be sent as a SINGLE bulk request, and both must land.
+func TestApplyChanges_CombinesUpdateAndCreateInOneRequest(t *testing.T) {
+	m := newDesecMock()
+	m.seed("a", "A", "1.1.1.1")
+	srv := m.server(t)
+	client := newTestClient(t, srv)
+
+	changes := plan.Changes{
+		UpdateNew: []*endpoint.Endpoint{
+			{DNSName: "a.example.com", RecordType: "A", Targets: endpoint.Targets{"2.2.2.2"}, RecordTTL: 3600},
+		},
+		Create: []*endpoint.Endpoint{
+			{DNSName: "b.example.com", RecordType: "A", Targets: endpoint.Targets{"3.3.3.3"}, RecordTTL: 3600},
+		},
+	}
+
+	err := client.ApplyChanges(changes)
+	if err != nil {
+		t.Fatalf("ApplyChanges(update+create) returned error: %v", err)
+	}
+
+	m.mu.Lock()
+	count := m.requestCount
+	aRecs := m.zone[zoneKey("a", "A")]
+	bRecs := m.zone[zoneKey("b", "A")]
+	m.mu.Unlock()
+
+	if count != 1 {
+		t.Errorf("expected exactly 1 bulk request to the domain, got %d", count)
+	}
+	if len(aRecs) != 1 || aRecs[0] != "2.2.2.2" {
+		t.Errorf("a.example.com A must be updated to 2.2.2.2, got %v", aRecs)
+	}
+	if len(bRecs) != 1 || bRecs[0] != "3.3.3.3" {
+		t.Errorf("b.example.com A must be created as 3.3.3.3, got %v", bRecs)
+	}
+}
+
+// Test 4 (dry-run safety): dry-run must not touch the API at all.
+func TestApplyChanges_DryRunMakesNoRequests(t *testing.T) {
+	m := newDesecMock()
+	srv := m.server(t)
+	client := newTestClient(t, srv)
+	client.dryRun = true
+
+	changes := plan.Changes{
+		Create: []*endpoint.Endpoint{
+			{DNSName: "x.example.com", RecordType: "A", Targets: endpoint.Targets{"9.9.9.9"}, RecordTTL: 3600},
+		},
+		UpdateNew: []*endpoint.Endpoint{
+			{DNSName: "y.example.com", RecordType: "A", Targets: endpoint.Targets{"8.8.8.8"}, RecordTTL: 3600},
+		},
+		Delete: []*endpoint.Endpoint{
+			{DNSName: "z.example.com", RecordType: "A", Targets: endpoint.Targets{"7.7.7.7"}, RecordTTL: 3600},
+		},
+	}
+
+	if err := client.ApplyChanges(changes); err != nil {
+		t.Fatalf("dry-run ApplyChanges returned error: %v", err)
+	}
+
+	m.mu.Lock()
+	count := m.requestCount
+	m.mu.Unlock()
+	if count != 0 {
+		t.Errorf("dry-run must make no API requests, got %d", count)
+	}
+}

--- a/internal/provider/desec_test.go
+++ b/internal/provider/desec_test.go
@@ -1,7 +1,9 @@
 package provider
 
 import (
+	"encoding/json"
 	"reflect"
+	"strings"
 	"testing"
 
 	"github.com/michelangelomo/external-dns-desec-provider/internal/config"
@@ -986,5 +988,30 @@ func TestSubDomainConvertEndpointToRRSet(t *testing.T) {
 				t.Errorf("convertEndpointToRRSet() = %+v, want %+v", result, tt.expected)
 			}
 		})
+	}
+}
+
+// TestApexRRSetJSONIncludesEmptySubname is a regression guard for
+// nrdcg/desec#fd7f5e0 ("fix: subname as empty string"), released in
+// v0.11.2. Before the fix, RRSet.SubName was tagged
+// `json:"subname,omitempty"`, which dropped the field for apex RRsets
+// and triggered `400 {"subname":["This field is required."]}` from the
+// deSEC API. If the dependency ever rolls back to a release that
+// reintroduces omitempty, this test fails loudly. See bug-2.md.
+func TestApexRRSetJSONIncludesEmptySubname(t *testing.T) {
+	rrset := convertEndpointToRRSet(&endpoint.Endpoint{
+		DNSName:    "example.com",
+		RecordType: "A",
+		Targets:    endpoint.Targets{"192.0.2.1"},
+		RecordTTL:  3600,
+	}, "example.com", 3600)
+
+	out, err := json.Marshal(rrset)
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+
+	if !strings.Contains(string(out), `"subname":""`) {
+		t.Errorf("apex RRSet JSON must include `\"subname\":\"\"` (deSEC rejects POST bodies without subname): got %s", out)
 	}
 }

--- a/internal/provider/desec_test.go
+++ b/internal/provider/desec_test.go
@@ -476,7 +476,7 @@ func TestConvertRRSetToEndpointExtended(t *testing.T) {
 			},
 			domain: "example.com",
 			expected: &endpoint.Endpoint{
-				DNSName:    "www.example.com.",
+				DNSName:    "www.example.com",
 				RecordType: "A",
 				Targets:    endpoint.Targets{"192.0.2.1", "192.0.2.2"},
 				RecordTTL:  300,
@@ -492,14 +492,14 @@ func TestConvertRRSetToEndpointExtended(t *testing.T) {
 			},
 			domain: "example.com",
 			expected: &endpoint.Endpoint{
-				DNSName:    "_dmarc.example.com.",
+				DNSName:    "_dmarc.example.com",
 				RecordType: "TXT",
 				Targets:    endpoint.Targets{"v=DMARC1; p=reject"},
 				RecordTTL:  3600,
 			},
 		},
 		{
-			name: "Domain with trailing dot",
+			name: "Apex record with dotted domain still emits dotless DNSName",
 			input: &desec.RRSet{
 				SubName: "",
 				Type:    "A",
@@ -508,7 +508,7 @@ func TestConvertRRSetToEndpointExtended(t *testing.T) {
 			},
 			domain: "example.com.",
 			expected: &endpoint.Endpoint{
-				DNSName:    "example.com.",
+				DNSName:    "example.com",
 				RecordType: "A",
 				Targets:    endpoint.Targets{"192.0.2.1"},
 				RecordTTL:  300,
@@ -782,6 +782,40 @@ func TestAdjustEndpoints(t *testing.T) {
 
 			if !reflect.DeepEqual(result, tt.expected) {
 				t.Errorf("AdjustEndpoints() = %+v, want %+v", result, tt.expected)
+			}
+		})
+	}
+}
+
+// TestConvertRRSetToEndpoint_DNSNameHasNoTrailingDot pins the read-path
+// invariant that prevents the providerSpecific txt/force-update=true loop:
+// external-dns sources emit DNSName without a trailing dot, and the TXT
+// registry matches companion records by exact-string DNSName. If /records
+// returns a dotted form, every reconcile produces a no-op Update on every
+// record (observed in deploy as "0 creates, 10 updates, 0 deletes").
+func TestConvertRRSetToEndpoint_DNSNameHasNoTrailingDot(t *testing.T) {
+	cases := []struct {
+		name    string
+		subname string
+		domain  string
+		want    string
+	}{
+		{"subdomain", "www", "example.com", "www.example.com"},
+		{"apex", "", "example.com", "example.com"},
+		{"deep subdomain", "foo.bar", "example.com", "foo.bar.example.com"},
+		{"domain passed with trailing dot still strips", "www", "example.com.", "www.example.com"},
+		{"apex with domain trailing dot still strips", "", "example.com.", "example.com"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			ep := convertRRSetToEndpoint(&desec.RRSet{
+				SubName: tc.subname,
+				Type:    "A",
+				Records: []string{"192.0.2.1"},
+				TTL:     3600,
+			}, tc.domain)
+			if ep.DNSName != tc.want {
+				t.Errorf("DNSName = %q, want %q", ep.DNSName, tc.want)
 			}
 		})
 	}

--- a/internal/provider/desec_test.go
+++ b/internal/provider/desec_test.go
@@ -1,6 +1,7 @@
 package provider
 
 import (
+	"context"
 	"encoding/json"
 	"reflect"
 	"strings"
@@ -569,7 +570,7 @@ func TestApplyChangesDryRun(t *testing.T) {
 	}
 
 	// This should not return an error in dry run mode
-	err = client.ApplyChanges(changes)
+	err = client.ApplyChanges(context.Background(), changes)
 	if err != nil {
 		t.Errorf("ApplyChanges in dry run mode returned error: %v", err)
 	}

--- a/internal/provider/ratelimit.go
+++ b/internal/provider/ratelimit.go
@@ -1,0 +1,95 @@
+package provider
+
+import (
+	"fmt"
+	"net/http"
+	"strconv"
+	"sync"
+	"time"
+)
+
+// RateLimitError is returned when a deSEC API call is short-circuited because
+// the client is still inside a throttle window observed from a prior 429
+// response. Returning this instead of hitting the API prevents the daily quota
+// from being burned while external-dns keeps retrying.
+type RateLimitError struct {
+	RetryAfter time.Duration
+}
+
+func (e *RateLimitError) Error() string {
+	return fmt.Sprintf("deSEC rate limit active, retry after %s", e.RetryAfter)
+}
+
+// rateLimitTracker remembers the next time the client should attempt to call
+// the deSEC API, derived from Retry-After headers seen on 429 responses.
+type rateLimitTracker struct {
+	mu            sync.Mutex
+	nextAllowedAt time.Time
+	now           func() time.Time
+}
+
+func newRateLimitTracker() *rateLimitTracker {
+	return &rateLimitTracker{now: time.Now}
+}
+
+// record extends the throttle window. A shorter delay than the current
+// deadline is ignored so a later 429 with a smaller Retry-After can't shorten
+// a longer window already in effect.
+func (t *rateLimitTracker) record(d time.Duration) {
+	if d <= 0 {
+		return
+	}
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	deadline := t.now().Add(d)
+	if deadline.After(t.nextAllowedAt) {
+		t.nextAllowedAt = deadline
+	}
+}
+
+// wait returns the remaining throttle duration; 0 means the client may proceed.
+func (t *rateLimitTracker) wait() time.Duration {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	remaining := t.nextAllowedAt.Sub(t.now())
+	if remaining < 0 {
+		return 0
+	}
+	return remaining
+}
+
+// rateLimitTransport is an http.RoundTripper that records Retry-After from any
+// 429 Too Many Requests responses observed on the wire, including ones
+// retryablehttp will subsequently retry.
+type rateLimitTransport struct {
+	inner   http.RoundTripper
+	tracker *rateLimitTracker
+}
+
+func (rt *rateLimitTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	resp, err := rt.inner.RoundTrip(req)
+	if err != nil || resp == nil {
+		return resp, err
+	}
+	if resp.StatusCode == http.StatusTooManyRequests {
+		if d, ok := parseRetryAfter(resp.Header.Get("Retry-After"), rt.tracker.now()); ok {
+			rt.tracker.record(d)
+		}
+	}
+	return resp, nil
+}
+
+// parseRetryAfter parses an HTTP Retry-After header value, which RFC 7231
+// defines as either delta-seconds or an HTTP-date, relative to `now`.
+func parseRetryAfter(value string, now time.Time) (time.Duration, bool) {
+	if value == "" {
+		return 0, false
+	}
+	if secs, err := strconv.Atoi(value); err == nil {
+		return time.Duration(secs) * time.Second, true
+	}
+	if t, err := http.ParseTime(value); err == nil {
+		return t.Sub(now), true
+	}
+	return 0, false
+}

--- a/internal/provider/ratelimit.go
+++ b/internal/provider/ratelimit.go
@@ -1,12 +1,34 @@
 package provider
 
 import (
+	"bytes"
 	"fmt"
+	"io"
 	"net/http"
 	"strconv"
 	"sync"
 	"time"
+
+	log "github.com/sirupsen/logrus"
 )
+
+// deSEC applies several throttle scopes; the one that bites the read path is
+// the account-wide `user` scope of 2000 requests/day, shared across ALL
+// domains and both read and write. When it is exhausted deSEC answers 429 with
+// a Retry-After that can be ~12.5h (the remaining seconds of the daily bucket).
+// The per-request read scope `dns_api_cheap` (10/s 50/min) is comparatively
+// generous and is not the limit we hit in practice.
+// https://desec.readthedocs.io/en/latest/rate-limits.html
+const userDailyRequestLimit = 2000
+
+// retryAfterCap bounds how long a single retryablehttp attempt may sleep on a
+// 429. The deSEC library builds its retry client internally and exposes no
+// Backoff hook, so we clamp the Retry-After header the transport hands upward:
+// DefaultBackoff sleeps the header value verbatim (not clamped to
+// RetryWaitMax), which is how a 429 turned into a silent ~12.5h sleep. The
+// unclamped duration is still recorded in the tracker so the next call
+// short-circuits for the real window.
+const retryAfterCap = 30 * time.Second
 
 // RateLimitError is returned when a deSEC API call is short-circuited because
 // the client is still inside a throttle window observed from a prior 429
@@ -21,15 +43,45 @@ func (e *RateLimitError) Error() string {
 }
 
 // rateLimitTracker remembers the next time the client should attempt to call
-// the deSEC API, derived from Retry-After headers seen on 429 responses.
+// the deSEC API, derived from Retry-After headers seen on 429 responses. It
+// also counts requests within the current UTC day to warn before the
+// account-wide `user` daily quota is exhausted.
 type rateLimitTracker struct {
 	mu            sync.Mutex
 	nextAllowedAt time.Time
 	now           func() time.Time
+
+	dayStart  time.Time
+	dayCount  int
+	warnedDay bool
 }
 
 func newRateLimitTracker() *rateLimitTracker {
 	return &rateLimitTracker{now: time.Now}
+}
+
+// observeRequest counts every request against the daily `user` budget and warns
+// once per day when the remaining budget runs low, so the eventual 429 is not
+// the first sign that the account is out of quota. Records roll over on the UTC
+// day boundary deSEC uses to reset the bucket.
+func (t *rateLimitTracker) observeRequest() {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	day := t.now().UTC().Truncate(24 * time.Hour)
+	if day.After(t.dayStart) {
+		t.dayStart = day
+		t.dayCount = 0
+		t.warnedDay = false
+	}
+	t.dayCount++
+
+	const warnThreshold = userDailyRequestLimit * 9 / 10
+	if t.dayCount >= warnThreshold && !t.warnedDay {
+		t.warnedDay = true
+		log.Warnf("approaching deSEC daily request limit: %d/%d requests today (account-wide, all domains)",
+			t.dayCount, userDailyRequestLimit)
+	}
 }
 
 // record extends the throttle window. A shorter delay than the current
@@ -67,16 +119,43 @@ type rateLimitTransport struct {
 }
 
 func (rt *rateLimitTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	rt.tracker.observeRequest()
 	resp, err := rt.inner.RoundTrip(req)
 	if err != nil || resp == nil {
 		return resp, err
 	}
 	if resp.StatusCode == http.StatusTooManyRequests {
-		if d, ok := parseRetryAfter(resp.Header.Get("Retry-After"), rt.tracker.now()); ok {
+		retryAfter := resp.Header.Get("Retry-After")
+		log.Warnf("deSEC throttled %s %s: HTTP 429, Retry-After=%q, detail=%q",
+			req.Method, req.URL.Path, retryAfter, peekThrottleDetail(resp))
+		if d, ok := parseRetryAfter(retryAfter, rt.tracker.now()); ok {
+			// Record the real window so the next call short-circuits, but clamp
+			// the header retryablehttp sees so a single attempt can never sleep
+			// for hours if the request context is not cancelled in time.
 			rt.tracker.record(d)
+			if d > retryAfterCap {
+				resp.Header.Set("Retry-After", strconv.Itoa(int(retryAfterCap/time.Second)))
+			}
 		}
 	}
 	return resp, nil
+}
+
+// peekThrottleDetail reads deSEC's JSON throttle body ("Request was throttled.
+// Expected available in N seconds.") for logging, then rewinds it so the caller
+// can still consume the response.
+func peekThrottleDetail(resp *http.Response) string {
+	if resp.Body == nil {
+		return ""
+	}
+	body, err := io.ReadAll(io.LimitReader(resp.Body, 512))
+	if err != nil {
+		return ""
+	}
+	rest, _ := io.ReadAll(resp.Body)
+	_ = resp.Body.Close()
+	resp.Body = io.NopCloser(io.MultiReader(bytes.NewReader(body), bytes.NewReader(rest)))
+	return string(body)
 }
 
 // parseRetryAfter parses an HTTP Retry-After header value, which RFC 7231

--- a/internal/provider/ratelimit.go
+++ b/internal/provider/ratelimit.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"net/http"
 	"strconv"
+	"strings"
 	"sync"
 	"time"
 
@@ -110,16 +111,186 @@ func (t *rateLimitTracker) wait() time.Duration {
 	return remaining
 }
 
-// rateLimitTransport is an http.RoundTripper that records Retry-After from any
-// 429 Too Many Requests responses observed on the wire, including ones
-// retryablehttp will subsequently retry.
+// deSEC rate-limit scopes exercised by this provider, from
+// https://desec.readthedocs.io/en/latest/rate-limits.html. Requests are checked
+// against these BEFORE going on the wire, so we avoid the 429 rather than react
+// to it. Sub-minute windows are cheap to wait out; the hour/day windows are
+// short-circuited to the cache/500 path instead of sleeping for hours.
+//
+//	dns_api_cheap                 10/s,  50/min                 reads, per user
+//	dns_api_per_domain_expensive  2/s, 15/min, 100/h, 300/day   writes, per user PER DOMAIN
+//	user                          2000/day                      any request, account-wide
+var (
+	cheapWindows      = []windowLimit{{10, time.Second}, {50, time.Minute}}
+	expensiveWindows  = []windowLimit{{2, time.Second}, {15, time.Minute}, {100, time.Hour}, {300, 24 * time.Hour}}
+	userDailyWindow   = []windowLimit{{userDailyRequestLimit, 24 * time.Hour}}
+	proactiveSleepCap = 5 * time.Second
+)
+
+// windowLimit is a max request count within a sliding time window.
+type windowLimit struct {
+	limit  int
+	window time.Duration
+}
+
+// slidingWindow tracks recent grant timestamps within its window and hands out
+// slots up to limit. It is the building block of every deSEC scope bucket.
+type slidingWindow struct {
+	windowLimit
+	grants []time.Time
+}
+
+// reserve, given the current time, either records a grant and returns (0, true)
+// or, if the window is full, returns the wait until the oldest grant expires and
+// (_, false). Expired grants are pruned on every call.
+func (w *slidingWindow) reserve(now time.Time) (time.Duration, bool) {
+	cutoff := now.Add(-w.window)
+	kept := w.grants[:0]
+	for _, g := range w.grants {
+		if g.After(cutoff) {
+			kept = append(kept, g)
+		}
+	}
+	w.grants = kept
+
+	if len(w.grants) < w.limit {
+		w.grants = append(w.grants, now)
+		return 0, true
+	}
+	// Full: the oldest grant must age out of the window before a slot frees.
+	return w.grants[0].Sub(cutoff), false
+}
+
+// scopeLimiter guards one deSEC scope key (a fixed scope, or a scope+domain for
+// the per-domain expensive bucket) with a sliding window per configured limit.
+type scopeLimiter struct {
+	mu      sync.Mutex
+	windows []*slidingWindow
+}
+
+func newScopeLimiter(limits []windowLimit) *scopeLimiter {
+	windows := make([]*slidingWindow, len(limits))
+	for i, l := range limits {
+		windows[i] = &slidingWindow{windowLimit: l}
+	}
+	return &scopeLimiter{windows: windows}
+}
+
+// proactiveLimiter holds the per-scope buckets consulted before a request. The
+// per-domain expensive scope is keyed lazily as domains are seen.
+type proactiveLimiter struct {
+	mu        sync.Mutex
+	cheap     *scopeLimiter
+	user      *scopeLimiter
+	expensive map[string]*scopeLimiter
+	now       func() time.Time
+}
+
+func newProactiveLimiter(now func() time.Time) *proactiveLimiter {
+	return &proactiveLimiter{
+		cheap:     newScopeLimiter(cheapWindows),
+		user:      newScopeLimiter(userDailyWindow),
+		expensive: make(map[string]*scopeLimiter),
+		now:       now,
+	}
+}
+
+func (p *proactiveLimiter) expensiveFor(domain string) *scopeLimiter {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	sl := p.expensive[domain]
+	if sl == nil {
+		sl = newScopeLimiter(expensiveWindows)
+		p.expensive[domain] = sl
+	}
+	return sl
+}
+
+// reserve checks the buckets for a read or write request against domain. It
+// returns the duration to sleep before proceeding (bounded by the caller) for
+// sub-minute windows, and shortCircuit=true with a *RateLimitError-worthy wait
+// when an hour/day window is full -- those must not be slept on. A slot is
+// reserved in every consulted window only when the whole request is admissible.
+func (p *proactiveLimiter) reserve(write bool, domain string) (sleep time.Duration, shortCircuit time.Duration) {
+	scopes := []*scopeLimiter{p.user}
+	if write {
+		scopes = append(scopes, p.expensiveFor(domain))
+	} else {
+		scopes = append(scopes, p.cheap)
+	}
+
+	now := p.now()
+
+	// First pass: probe without committing. If any hour/day window is full,
+	// short-circuit; otherwise take the longest sub-minute wait to sleep out.
+	// Probing avoids reserving slots we'd then abandon on a short-circuit.
+	var maxSleep, maxShort time.Duration
+	for _, sc := range scopes {
+		sc.mu.Lock()
+		for _, w := range sc.windows {
+			cutoff := now.Add(-w.window)
+			active := 0
+			var oldest time.Time
+			for _, g := range w.grants {
+				if g.After(cutoff) {
+					if active == 0 || g.Before(oldest) {
+						oldest = g
+					}
+					active++
+				}
+			}
+			if active < w.limit {
+				continue
+			}
+			wait := oldest.Sub(cutoff)
+			if w.window <= time.Minute {
+				if wait > maxSleep {
+					maxSleep = wait
+				}
+			} else if wait > maxShort {
+				maxShort = wait
+			}
+		}
+		sc.mu.Unlock()
+	}
+	if maxShort > 0 {
+		return 0, maxShort
+	}
+	if maxSleep > 0 {
+		return maxSleep, 0
+	}
+
+	// Admissible now: commit a grant in every window of every consulted scope.
+	for _, sc := range scopes {
+		sc.mu.Lock()
+		for _, w := range sc.windows {
+			_, _ = w.reserve(now)
+		}
+		sc.mu.Unlock()
+	}
+	return 0, 0
+}
+
+// rateLimitTransport is an http.RoundTripper that proactively throttles against
+// deSEC's documented scopes before a request, and reactively records Retry-After
+// from any 429 Too Many Requests responses observed on the wire (including ones
+// retryablehttp will subsequently retry). The reactive window always wins: a
+// recorded Retry-After short-circuits regardless of the proactive buckets.
 type rateLimitTransport struct {
-	inner   http.RoundTripper
-	tracker *rateLimitTracker
+	inner     http.RoundTripper
+	tracker   *rateLimitTracker
+	proactive *proactiveLimiter
 }
 
 func (rt *rateLimitTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 	rt.tracker.observeRequest()
+
+	if rt.proactive != nil {
+		if err := rt.applyProactive(req); err != nil {
+			return nil, err
+		}
+	}
+
 	resp, err := rt.inner.RoundTrip(req)
 	if err != nil || resp == nil {
 		return resp, err
@@ -139,6 +310,59 @@ func (rt *rateLimitTransport) RoundTrip(req *http.Request) (*http.Response, erro
 		}
 	}
 	return resp, nil
+}
+
+// applyProactive enforces the proactive scope buckets and the reactive
+// Retry-After window before a request goes on the wire. The reactive window
+// always wins (max of the two next-allowed times): an hour/day scope or an open
+// 429 window short-circuits with a *RateLimitError so the caller falls to the
+// cache/500 path; a sub-minute scope is slept out, bounded by proactiveSleepCap
+// and honouring the request context.
+func (rt *rateLimitTransport) applyProactive(req *http.Request) error {
+	write, domain := classifyRRSetRequest(req)
+
+	sleep, shortCircuit := rt.proactive.reserve(write, domain)
+
+	// The reactive window (recorded from a prior 429) always wins.
+	if reactive := rt.tracker.wait(); reactive > shortCircuit {
+		shortCircuit = reactive
+	}
+	if shortCircuit > 0 {
+		return &RateLimitError{RetryAfter: shortCircuit}
+	}
+
+	if sleep > 0 {
+		if sleep > proactiveSleepCap {
+			sleep = proactiveSleepCap
+		}
+		t := time.NewTimer(sleep)
+		defer t.Stop()
+		select {
+		case <-t.C:
+		case <-req.Context().Done():
+			return req.Context().Err()
+		}
+	}
+	return nil
+}
+
+// classifyRRSetRequest inspects a deSEC rrsets request and reports whether it is
+// a write (mutating method) and the domain it targets. deSEC's URL shape is
+// /domains/<domain>/rrsets[/<subname>/<type>], so the segment after "domains"
+// is the per-domain key for the expensive write scope.
+func classifyRRSetRequest(req *http.Request) (write bool, domain string) {
+	switch req.Method {
+	case http.MethodPut, http.MethodPost, http.MethodPatch, http.MethodDelete:
+		write = true
+	}
+	parts := strings.Split(strings.Trim(req.URL.Path, "/"), "/")
+	for i, p := range parts {
+		if p == "domains" && i+1 < len(parts) {
+			domain = parts[i+1]
+			break
+		}
+	}
+	return write, domain
 }
 
 // peekThrottleDetail reads deSEC's JSON throttle body ("Request was throttled.

--- a/internal/provider/ratelimit_test.go
+++ b/internal/provider/ratelimit_test.go
@@ -1,0 +1,179 @@
+package provider
+
+import (
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/michelangelomo/external-dns-desec-provider/internal/config"
+	"sigs.k8s.io/external-dns/endpoint"
+	"sigs.k8s.io/external-dns/plan"
+)
+
+func TestRateLimitTracker_RecordsRetryAfter(t *testing.T) {
+	now := time.Date(2026, 5, 19, 12, 0, 0, 0, time.UTC)
+	tr := &rateLimitTracker{now: func() time.Time { return now }}
+
+	tr.record(5 * time.Second)
+
+	if got := tr.wait(); got != 5*time.Second {
+		t.Errorf("wait() = %s, want 5s", got)
+	}
+}
+
+func TestRateLimitTracker_AllowsAfterExpiry(t *testing.T) {
+	cur := time.Date(2026, 5, 19, 12, 0, 0, 0, time.UTC)
+	tr := &rateLimitTracker{now: func() time.Time { return cur }}
+
+	tr.record(5 * time.Second)
+	cur = cur.Add(6 * time.Second)
+
+	if got := tr.wait(); got != 0 {
+		t.Errorf("wait() = %s, want 0", got)
+	}
+}
+
+func TestRateLimitTracker_DoesNotShrinkWindow(t *testing.T) {
+	cur := time.Date(2026, 5, 19, 12, 0, 0, 0, time.UTC)
+	tr := &rateLimitTracker{now: func() time.Time { return cur }}
+
+	tr.record(60 * time.Second)
+	tr.record(5 * time.Second) // a shorter retry-after must not shrink the window
+
+	if got := tr.wait(); got != 60*time.Second {
+		t.Errorf("wait() = %s, want 60s", got)
+	}
+}
+
+func TestRateLimitTracker_IgnoresNonPositive(t *testing.T) {
+	cur := time.Date(2026, 5, 19, 12, 0, 0, 0, time.UTC)
+	tr := &rateLimitTracker{now: func() time.Time { return cur }}
+
+	tr.record(0)
+	tr.record(-5 * time.Second)
+
+	if got := tr.wait(); got != 0 {
+		t.Errorf("wait() = %s, want 0", got)
+	}
+}
+
+func TestParseRetryAfter_Seconds(t *testing.T) {
+	d, ok := parseRetryAfter("120", time.Now())
+	if !ok || d != 120*time.Second {
+		t.Errorf("parseRetryAfter(\"120\") = (%s, %v), want (2m, true)", d, ok)
+	}
+}
+
+func TestParseRetryAfter_HTTPDate(t *testing.T) {
+	now := time.Date(2026, 5, 19, 12, 0, 0, 0, time.UTC)
+	target := now.Add(90 * time.Second)
+	value := target.Format(http.TimeFormat)
+
+	d, ok := parseRetryAfter(value, now)
+	if !ok {
+		t.Fatalf("parseRetryAfter(%q) returned ok=false", value)
+	}
+	if d < 89*time.Second || d > 91*time.Second {
+		t.Errorf("parseRetryAfter date duration = %s, want ~90s", d)
+	}
+}
+
+func TestParseRetryAfter_Invalid(t *testing.T) {
+	tests := []string{"", "garbage", "not-a-number"}
+	for _, v := range tests {
+		if _, ok := parseRetryAfter(v, time.Now()); ok {
+			t.Errorf("parseRetryAfter(%q) returned ok=true, want false", v)
+		}
+	}
+}
+
+func TestRateLimitTransport_CapturesRetryAfter(t *testing.T) {
+	var requests int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests++
+		w.Header().Set("Retry-After", "60")
+		w.WriteHeader(http.StatusTooManyRequests)
+	}))
+	defer server.Close()
+
+	tracker := newRateLimitTracker()
+	client := &http.Client{
+		Transport: &rateLimitTransport{inner: http.DefaultTransport, tracker: tracker},
+	}
+
+	req, _ := http.NewRequest(http.MethodGet, server.URL, nil)
+	resp, err := client.Do(req)
+	if err != nil {
+		t.Fatalf("Do: %v", err)
+	}
+	_ = resp.Body.Close()
+
+	if requests != 1 {
+		t.Errorf("expected 1 request, got %d", requests)
+	}
+	if d := tracker.wait(); d < 59*time.Second || d > 61*time.Second {
+		t.Errorf("tracker.wait() = %s, want ~60s", d)
+	}
+}
+
+func TestRateLimitTransport_IgnoresNon429(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Retry-After", "60") // present but irrelevant on 200
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	tracker := newRateLimitTracker()
+	client := &http.Client{
+		Transport: &rateLimitTransport{inner: http.DefaultTransport, tracker: tracker},
+	}
+
+	req, _ := http.NewRequest(http.MethodGet, server.URL, nil)
+	resp, err := client.Do(req)
+	if err != nil {
+		t.Fatalf("Do: %v", err)
+	}
+	_ = resp.Body.Close()
+
+	if d := tracker.wait(); d != 0 {
+		t.Errorf("tracker.wait() = %s after 200 OK, want 0", d)
+	}
+}
+
+func TestApplyChanges_ShortCircuitsDuringThrottle(t *testing.T) {
+	cfg := config.Config{
+		APIToken:      "test-token",
+		DomainFilters: []string{"example.com"},
+		DefaultTTL:    3600,
+	}
+	client, err := CreateDesecClient(cfg)
+	if err != nil {
+		t.Fatalf("CreateDesecClient: %v", err)
+	}
+
+	client.rateLimit.record(10 * time.Minute)
+
+	err = client.ApplyChanges(plan.Changes{
+		Create: []*endpoint.Endpoint{
+			{
+				DNSName:    "x.example.com",
+				RecordType: "A",
+				Targets:    endpoint.Targets{"192.0.2.1"},
+				RecordTTL:  3600,
+			},
+		},
+	})
+
+	if err == nil {
+		t.Fatal("expected RateLimitError, got nil")
+	}
+	var rle *RateLimitError
+	if !errors.As(err, &rle) {
+		t.Fatalf("expected *RateLimitError, got %T: %v", err, err)
+	}
+	if rle.RetryAfter < 9*time.Minute {
+		t.Errorf("RetryAfter = %s, want at least 9m", rle.RetryAfter)
+	}
+}

--- a/internal/provider/ratelimit_test.go
+++ b/internal/provider/ratelimit_test.go
@@ -215,6 +215,63 @@ func TestGetEndpoints_ShortCircuitsDuringThrottle(t *testing.T) {
 	}
 }
 
+func TestCachedEndpoints_AllOrNothing(t *testing.T) {
+	now := time.Date(2026, 5, 19, 12, 0, 0, 0, time.UTC)
+	client, err := CreateDesecClient(config.Config{
+		APIToken:      "test-token",
+		DomainFilters: []string{"a.example", "b.example"},
+		DefaultTTL:    3600,
+	})
+	if err != nil {
+		t.Fatalf("CreateDesecClient: %v", err)
+	}
+	client.rateLimit.now = func() time.Time { return now }
+
+	client.cache["a.example"] = cachedEndpoints{
+		endpoints: []*endpoint.Endpoint{{DNSName: "x.a.example", RecordType: "A"}},
+		fetchedAt: now,
+	}
+
+	// b.example was never fetched -> all-or-nothing must refuse.
+	if _, ok := client.CachedEndpoints([]string{"a.example", "b.example"}); ok {
+		t.Fatal("CachedEndpoints returned ok with a missing domain; must be all-or-nothing")
+	}
+
+	client.cache["b.example"] = cachedEndpoints{
+		endpoints: []*endpoint.Endpoint{{DNSName: "y.b.example", RecordType: "A"}},
+		fetchedAt: now,
+	}
+	eps, ok := client.CachedEndpoints([]string{"a.example", "b.example"})
+	if !ok {
+		t.Fatal("CachedEndpoints refused a full, fresh cache")
+	}
+	if len(eps) != 2 {
+		t.Errorf("cached endpoints = %d, want 2", len(eps))
+	}
+}
+
+func TestCachedEndpoints_RefusesStale(t *testing.T) {
+	now := time.Date(2026, 5, 19, 12, 0, 0, 0, time.UTC)
+	client, err := CreateDesecClient(config.Config{
+		APIToken:      "test-token",
+		DomainFilters: []string{"a.example"},
+		DefaultTTL:    3600,
+	})
+	if err != nil {
+		t.Fatalf("CreateDesecClient: %v", err)
+	}
+	client.rateLimit.now = func() time.Time { return now }
+
+	client.cache["a.example"] = cachedEndpoints{
+		endpoints: []*endpoint.Endpoint{{DNSName: "x.a.example", RecordType: "A"}},
+		fetchedAt: now.Add(-maxCacheStaleness - time.Minute),
+	}
+
+	if _, ok := client.CachedEndpoints([]string{"a.example"}); ok {
+		t.Error("CachedEndpoints served a cache older than maxCacheStaleness")
+	}
+}
+
 func TestApplyChanges_ShortCircuitsDuringThrottle(t *testing.T) {
 	cfg := config.Config{
 		APIToken:      "test-token",

--- a/internal/provider/ratelimit_test.go
+++ b/internal/provider/ratelimit_test.go
@@ -1,9 +1,12 @@
 package provider
 
 import (
+	"context"
 	"errors"
+	"io"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 
@@ -118,6 +121,44 @@ func TestRateLimitTransport_CapturesRetryAfter(t *testing.T) {
 	}
 }
 
+// TestRateLimitTransport_ClampsRetryAfterHeader pins the fix for the ~12.5h
+// silent sleep: a large Retry-After must be recorded verbatim in the tracker
+// (so the next call short-circuits for the real window) but clamped in the
+// response header the deSEC retry client sees, so a single retry can never
+// sleep for hours.
+func TestRateLimitTransport_ClampsRetryAfterHeader(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Retry-After", "45000") // deSEC daily-quota style value
+		w.WriteHeader(http.StatusTooManyRequests)
+		_, _ = w.Write([]byte(`{"detail":"Request was throttled. Expected available in 45000 seconds."}`))
+	}))
+	defer server.Close()
+
+	tracker := newRateLimitTracker()
+	client := &http.Client{
+		Transport: &rateLimitTransport{inner: http.DefaultTransport, tracker: tracker},
+	}
+
+	req, _ := http.NewRequest(http.MethodGet, server.URL, nil)
+	resp, err := client.Do(req)
+	if err != nil {
+		t.Fatalf("Do: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if got := resp.Header.Get("Retry-After"); got != "30" {
+		t.Errorf("clamped Retry-After header = %q, want \"30\"", got)
+	}
+	if d := tracker.wait(); d < 44900*time.Second {
+		t.Errorf("tracker.wait() = %s, want the full ~45000s window recorded", d)
+	}
+	// Body must survive the throttle-detail peek so the caller can still read it.
+	body, _ := io.ReadAll(resp.Body)
+	if !strings.Contains(string(body), "throttled") {
+		t.Errorf("response body was consumed by detail peek: %q", body)
+	}
+}
+
 func TestRateLimitTransport_IgnoresNon429(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Retry-After", "60") // present but irrelevant on 200
@@ -142,6 +183,38 @@ func TestRateLimitTransport_IgnoresNon429(t *testing.T) {
 	}
 }
 
+func TestGetEndpoints_ShortCircuitsDuringThrottle(t *testing.T) {
+	cfg := config.Config{
+		APIToken:      "test-token",
+		DomainFilters: []string{"example.com"},
+		DefaultTTL:    3600,
+	}
+	client, err := CreateDesecClient(cfg)
+	if err != nil {
+		t.Fatalf("CreateDesecClient: %v", err)
+	}
+
+	// Point at a server that fails the test if it is ever reached: an open
+	// throttle window must be answered from the tracker without a network call.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Errorf("deSEC must not be called while throttle window is open")
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+	client.client.BaseURL = srv.URL + "/"
+
+	client.rateLimit.record(10 * time.Minute)
+
+	_, err = client.GetEndpoints(context.Background(), "example.com")
+	var rle *RateLimitError
+	if !errors.As(err, &rle) {
+		t.Fatalf("expected *RateLimitError, got %T: %v", err, err)
+	}
+	if rle.RetryAfter < 9*time.Minute {
+		t.Errorf("RetryAfter = %s, want at least 9m", rle.RetryAfter)
+	}
+}
+
 func TestApplyChanges_ShortCircuitsDuringThrottle(t *testing.T) {
 	cfg := config.Config{
 		APIToken:      "test-token",
@@ -155,7 +228,7 @@ func TestApplyChanges_ShortCircuitsDuringThrottle(t *testing.T) {
 
 	client.rateLimit.record(10 * time.Minute)
 
-	err = client.ApplyChanges(plan.Changes{
+	err = client.ApplyChanges(context.Background(), plan.Changes{
 		Create: []*endpoint.Endpoint{
 			{
 				DNSName:    "x.example.com",

--- a/internal/provider/ratelimit_test.go
+++ b/internal/provider/ratelimit_test.go
@@ -215,6 +215,133 @@ func TestGetEndpoints_ShortCircuitsDuringThrottle(t *testing.T) {
 	}
 }
 
+func TestSlidingWindow_ReserveAndExpire(t *testing.T) {
+	now := time.Date(2026, 5, 19, 12, 0, 0, 0, time.UTC)
+	w := &slidingWindow{windowLimit: windowLimit{limit: 2, window: time.Second}}
+
+	if _, ok := w.reserve(now); !ok {
+		t.Fatal("first reserve must succeed")
+	}
+	if _, ok := w.reserve(now); !ok {
+		t.Fatal("second reserve must succeed")
+	}
+	wait, ok := w.reserve(now)
+	if ok {
+		t.Fatal("third reserve must be refused while window is full")
+	}
+	if wait <= 0 || wait > time.Second {
+		t.Errorf("wait = %s, want a positive sub-second value", wait)
+	}
+	// After the window elapses the oldest grant ages out.
+	if _, ok := w.reserve(now.Add(time.Second + time.Millisecond)); !ok {
+		t.Error("reserve must succeed once the window has elapsed")
+	}
+}
+
+// A read past the dns_api_cheap per-second limit must be told to sleep (a
+// sub-minute window), not short-circuited.
+func TestProactiveLimiter_ReadBlocksOnPerSecond(t *testing.T) {
+	now := time.Date(2026, 5, 19, 12, 0, 0, 0, time.UTC)
+	p := newProactiveLimiter(func() time.Time { return now })
+
+	for i := 0; i < 10; i++ { // exhaust the 10/s cheap window
+		if sleep, short := p.reserve(false, "example.com"); sleep != 0 || short != 0 {
+			t.Fatalf("read %d unexpectedly limited: sleep=%s short=%s", i, sleep, short)
+		}
+	}
+	sleep, short := p.reserve(false, "example.com")
+	if short != 0 {
+		t.Errorf("per-second read limit must sleep, not short-circuit (short=%s)", short)
+	}
+	if sleep <= 0 || sleep > time.Second {
+		t.Errorf("sleep = %s, want a positive sub-second value", sleep)
+	}
+}
+
+// A write past the per-domain expensive per-hour limit must short-circuit (an
+// hour window must never be slept on), surfaced to the caller as a wait.
+func TestProactiveLimiter_WriteShortCircuitsOnPerHour(t *testing.T) {
+	now := time.Date(2026, 5, 19, 12, 0, 0, 0, time.UTC)
+	p := newProactiveLimiter(func() time.Time { return now })
+
+	// Fill the per-hour window (100 grants) spaced 35s apart so they all stay
+	// within the hour but the 2/s and 15/min windows never trip first,
+	// isolating the hour window as the limiter that fires.
+	for i := 0; i < 100; i++ {
+		if sleep, short := p.reserve(true, "example.com"); sleep != 0 || short != 0 {
+			t.Fatalf("write %d unexpectedly limited: sleep=%s short=%s", i, sleep, short)
+		}
+		now = now.Add(35 * time.Second)
+	}
+	sleep, short := p.reserve(true, "example.com")
+	if sleep != 0 {
+		t.Errorf("per-hour write limit must short-circuit, not sleep (sleep=%s)", sleep)
+	}
+	if short <= 0 {
+		t.Errorf("expected a positive short-circuit wait, got %s", short)
+	}
+}
+
+// The per-domain expensive scope is keyed per domain: exhausting one domain's
+// window must not throttle another.
+func TestProactiveLimiter_ExpensiveIsPerDomain(t *testing.T) {
+	now := time.Date(2026, 5, 19, 12, 0, 0, 0, time.UTC)
+	p := newProactiveLimiter(func() time.Time { return now })
+
+	for i := 0; i < 2; i++ { // exhaust the 2/s window for a.example
+		if sleep, short := p.reserve(true, "a.example"); sleep != 0 || short != 0 {
+			t.Fatalf("write %d to a.example unexpectedly limited", i)
+		}
+	}
+	if sleep, short := p.reserve(true, "b.example"); sleep != 0 || short != 0 {
+		t.Errorf("b.example must not be throttled by a.example's window: sleep=%s short=%s", sleep, short)
+	}
+}
+
+// The reactive Retry-After window always wins over the proactive verdict.
+func TestApplyProactive_ReactiveWindowWins(t *testing.T) {
+	now := time.Date(2026, 5, 19, 12, 0, 0, 0, time.UTC)
+	tracker := &rateLimitTracker{now: func() time.Time { return now }}
+	tracker.record(10 * time.Minute)
+
+	rt := &rateLimitTransport{
+		inner:     http.DefaultTransport,
+		tracker:   tracker,
+		proactive: newProactiveLimiter(func() time.Time { return now }),
+	}
+
+	req, _ := http.NewRequest(http.MethodGet, "https://desec.io/api/v1/domains/example.com/rrsets/", nil)
+	err := rt.applyProactive(req)
+	var rle *RateLimitError
+	if !errors.As(err, &rle) {
+		t.Fatalf("expected *RateLimitError from the open reactive window, got %T: %v", err, err)
+	}
+	if rle.RetryAfter < 9*time.Minute {
+		t.Errorf("RetryAfter = %s, want the reactive 10m window", rle.RetryAfter)
+	}
+}
+
+func TestClassifyRRSetRequest(t *testing.T) {
+	tests := []struct {
+		method     string
+		path       string
+		wantWrite  bool
+		wantDomain string
+	}{
+		{http.MethodGet, "/api/v1/domains/example.com/rrsets/", false, "example.com"},
+		{http.MethodPut, "/api/v1/domains/example.com/rrsets/", true, "example.com"},
+		{http.MethodPost, "/api/v1/domains/sub.example.org/rrsets/", true, "sub.example.org"},
+		{http.MethodDelete, "/api/v1/domains/example.com/rrsets/www/A/", true, "example.com"},
+	}
+	for _, tt := range tests {
+		req, _ := http.NewRequest(tt.method, "https://desec.io"+tt.path, nil)
+		write, domain := classifyRRSetRequest(req)
+		if write != tt.wantWrite || domain != tt.wantDomain {
+			t.Errorf("classify(%s %s) = (%v, %q), want (%v, %q)", tt.method, tt.path, write, domain, tt.wantWrite, tt.wantDomain)
+		}
+	}
+}
+
 func TestCachedEndpoints_AllOrNothing(t *testing.T) {
 	now := time.Date(2026, 5, 19, 12, 0, 0, 0, time.UTC)
 	client, err := CreateDesecClient(config.Config{

--- a/internal/server/log.go
+++ b/internal/server/log.go
@@ -50,15 +50,15 @@ func NewLogger(opts ...LogOptions) *LoggingMiddleware {
 		opt = opts[0]
 	}
 
-	if opt.Formatter == nil {
-		opt.Formatter = &logrus.TextFormatter{
-			DisableColors:   true,
-			TimestampFormat: time.RFC3339,
-		}
+	// Use the app's standard logger so the middleware honours the configured
+	// level and output. A private logrus.New() here silently discards the
+	// start/completion lines (they were logged below the default level and to
+	// a separate sink), which hid that a /records handler had started but
+	// never completed during the deSEC throttle hang.
+	log := logrus.StandardLogger()
+	if opt.Formatter != nil {
+		log.Formatter = opt.Formatter
 	}
-
-	log := logrus.New()
-	log.Formatter = opt.Formatter
 
 	return &LoggingMiddleware{
 		logger:         log,

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
 
 	"github.com/gorilla/mux"
@@ -106,6 +107,11 @@ func (webhook webhook) recordsHandler(w http.ResponseWriter, r *http.Request) {
 }
 
 func (webhook webhook) applyChangesHandler(w http.ResponseWriter, r *http.Request) {
+	if err := dumpRequestBodyAtDebug(r, "/records"); err != nil {
+		w.WriteHeader(http.StatusBadRequest)
+		return
+	}
+
 	var changes plan.Changes
 
 	err := json.NewDecoder(r.Body).Decode(&changes)
@@ -125,6 +131,11 @@ func (webhook webhook) applyChangesHandler(w http.ResponseWriter, r *http.Reques
 }
 
 func (webhook webhook) adjustEndpointsHandler(w http.ResponseWriter, r *http.Request) {
+	if err := dumpRequestBodyAtDebug(r, "/adjustendpoints"); err != nil {
+		w.WriteHeader(http.StatusBadRequest)
+		return
+	}
+
 	adjustedEndpoints := []*endpoint.Endpoint{}
 
 	err := json.NewDecoder(r.Body).Decode(&adjustedEndpoints)
@@ -147,4 +158,24 @@ func (webhook webhook) adjustEndpointsHandler(w http.ResponseWriter, r *http.Req
 		return
 	}
 	_, _ = w.Write(buf.Bytes())
+}
+
+// dumpRequestBodyAtDebug logs the full request body when debug-level logging
+// is enabled, then rewinds r.Body so the handler can decode it normally.
+// Used to capture the full plan.Changes payload (including UpdateOld, Labels,
+// and ProviderSpecific) that the summary log lines do not show. The body
+// read is skipped entirely at info level so production deployments pay no
+// extra cost; enable with WEBHOOK_LOGLEVEL=debug.
+func dumpRequestBodyAtDebug(r *http.Request, label string) error {
+	if !log.IsLevelEnabled(log.DebugLevel) {
+		return nil
+	}
+	body, err := io.ReadAll(r.Body)
+	if err != nil {
+		log.Errorf("failed to read %s body for debug log: %v", label, err)
+		return err
+	}
+	log.Debugf("POST %s body: %s", label, string(body))
+	r.Body = io.NopCloser(bytes.NewReader(body))
+	return nil
 }

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -156,6 +156,7 @@ func (webhook webhook) applyChangesHandler(w http.ResponseWriter, r *http.Reques
 
 	err := json.NewDecoder(r.Body).Decode(&changes)
 	if err != nil {
+		log.Warnf("failed to decode /records POST body: %v", err)
 		w.WriteHeader(http.StatusBadRequest)
 		return
 	}
@@ -191,6 +192,7 @@ func (webhook webhook) adjustEndpointsHandler(w http.ResponseWriter, r *http.Req
 
 	err := json.NewDecoder(r.Body).Decode(&adjustedEndpoints)
 	if err != nil {
+		log.Warnf("failed to decode /adjustendpoints POST body: %v", err)
 		w.WriteHeader(http.StatusBadRequest)
 		return
 	}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -4,9 +4,11 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
+	"strconv"
 
 	"github.com/gorilla/mux"
 	"github.com/michelangelomo/external-dns-desec-provider/internal/config"
@@ -20,8 +22,17 @@ type WebhookServer struct {
 	httpServer *http.Server
 }
 
+// desecProvider is the subset of *provider.DesecClient the handlers use. An
+// interface here lets tests inject a throttled fake without driving a real
+// retry loop.
+type desecProvider interface {
+	GetEndpoints(ctx context.Context, domain string) ([]*endpoint.Endpoint, error)
+	ApplyChanges(ctx context.Context, changes plan.Changes) error
+	AdjustEndpoints(endpoints []*endpoint.Endpoint) ([]*endpoint.Endpoint, error)
+}
+
 type webhook struct {
-	desecClient *provider.DesecClient
+	desecClient desecProvider
 	config      config.Config
 }
 
@@ -29,7 +40,7 @@ const (
 	externalDnsWebhookHeader = "application/external.dns.webhook+json;version=1"
 )
 
-func NewWebhookServer(desecClient *provider.DesecClient, config config.Config) *WebhookServer {
+func NewWebhookServer(desecClient desecProvider, config config.Config) *WebhookServer {
 	var webhook webhook
 	webhook.desecClient = desecClient
 	webhook.config = config
@@ -86,8 +97,21 @@ func (webhook webhook) recordsHandler(w http.ResponseWriter, r *http.Request) {
 	endpoints := []*endpoint.Endpoint{}
 
 	for _, domain := range webhook.config.DomainFilters {
-		domainEndpoints, err := webhook.desecClient.GetEndpoints(domain)
+		domainEndpoints, err := webhook.desecClient.GetEndpoints(r.Context(), domain)
 		if err != nil {
+			// external-dns's webhook client treats 429 as a HARD fatal error and
+			// only 500..510 as a retryable SoftError, so a throttle must surface
+			// as 500 (logged + retried next interval, no crash) -- never 429. The
+			// real Retry-After is still exposed for operators even though
+			// external-dns ignores it.
+			var rle *provider.RateLimitError
+			if errors.As(err, &rle) {
+				log.Warnf("rate limited fetching records for domain %s: %v", domain, rle)
+				w.Header().Set("Retry-After", strconv.Itoa(int(rle.RetryAfter.Seconds())))
+				w.WriteHeader(http.StatusInternalServerError)
+				_, _ = fmt.Fprintf(w, "deSEC rate limit active, retry after %s", rle.RetryAfter)
+				return
+			}
 			log.Errorf("failed to get records for domain %s: %v", domain, err)
 			w.WriteHeader(http.StatusInternalServerError)
 			_, _ = fmt.Fprintf(w, "failed to get records for domain %s: %v", domain, err)
@@ -120,8 +144,19 @@ func (webhook webhook) applyChangesHandler(w http.ResponseWriter, r *http.Reques
 		return
 	}
 
-	err = webhook.desecClient.ApplyChanges(changes)
+	err = webhook.desecClient.ApplyChanges(r.Context(), changes)
 	if err != nil {
+		// A throttle on the write path is 500 for the same reason as the read
+		// path: 429 would be fatal to external-dns, 500 becomes a retryable
+		// SoftError. Expose the real Retry-After even though it is ignored.
+		var rle *provider.RateLimitError
+		if errors.As(err, &rle) {
+			log.Warnf("rate limited applying changes: %v", rle)
+			w.Header().Set("Retry-After", strconv.Itoa(int(rle.RetryAfter.Seconds())))
+			w.WriteHeader(http.StatusInternalServerError)
+			_, _ = fmt.Fprintf(w, "deSEC rate limit active, retry after %s", rle.RetryAfter)
+			return
+		}
 		log.Errorf("failed to apply changes: %v", err)
 		w.WriteHeader(http.StatusInternalServerError)
 		return

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -29,6 +29,8 @@ type desecProvider interface {
 	GetEndpoints(ctx context.Context, domain string) ([]*endpoint.Endpoint, error)
 	ApplyChanges(ctx context.Context, changes plan.Changes) error
 	AdjustEndpoints(endpoints []*endpoint.Endpoint) ([]*endpoint.Endpoint, error)
+	Throttled() bool
+	CachedEndpoints(domains []string) ([]*endpoint.Endpoint, bool)
 }
 
 type webhook struct {
@@ -99,14 +101,23 @@ func (webhook webhook) recordsHandler(w http.ResponseWriter, r *http.Request) {
 	for _, domain := range webhook.config.DomainFilters {
 		domainEndpoints, err := webhook.desecClient.GetEndpoints(r.Context(), domain)
 		if err != nil {
-			// external-dns's webhook client treats 429 as a HARD fatal error and
-			// only 500..510 as a retryable SoftError, so a throttle must surface
-			// as 500 (logged + retried next interval, no crash) -- never 429. The
-			// real Retry-After is still exposed for operators even though
-			// external-dns ignores it.
 			var rle *provider.RateLimitError
 			if errors.As(err, &rle) {
-				log.Warnf("rate limited fetching records for domain %s: %v", domain, rle)
+				// While throttled, prefer last-known-good records over failing:
+				// serve them as 200 only when EVERY domain has a usable cache
+				// entry (all-or-nothing). A partial set under --policy=sync would
+				// make external-dns recreate the missing domain's records.
+				if cached, ok := webhook.desecClient.CachedEndpoints(webhook.config.DomainFilters); ok {
+					log.Warnf("deSEC throttled; serving %d cached records (retry after %s)", len(cached), rle.RetryAfter)
+					writeEndpoints(w, cached)
+					return
+				}
+				// No usable cache: external-dns treats 429 as a HARD fatal error
+				// and only 500..510 as a retryable SoftError, so surface 500
+				// (logged + retried next interval, no crash) -- never 429. The
+				// real Retry-After is exposed for operators even though
+				// external-dns ignores it.
+				log.Warnf("rate limited fetching records for domain %s, no usable cache: %v", domain, rle)
 				w.Header().Set("Retry-After", strconv.Itoa(int(rle.RetryAfter.Seconds())))
 				w.WriteHeader(http.StatusInternalServerError)
 				_, _ = fmt.Fprintf(w, "deSEC rate limit active, retry after %s", rle.RetryAfter)
@@ -121,6 +132,11 @@ func (webhook webhook) recordsHandler(w http.ResponseWriter, r *http.Request) {
 		endpoints = append(endpoints, domainEndpoints...)
 	}
 
+	writeEndpoints(w, endpoints)
+}
+
+// writeEndpoints encodes an endpoint slice as the webhook /records 200 body.
+func writeEndpoints(w http.ResponseWriter, endpoints []*endpoint.Endpoint) {
 	var buf bytes.Buffer
 	if err := json.NewEncoder(&buf).Encode(endpoints); err != nil {
 		log.Errorf("failed to encode endpoints: %v", err)

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -367,6 +367,87 @@ func TestWebhookServerShutdown(t *testing.T) {
 	}
 }
 
+// TestApplyChangesHandler_DebugBodyDump verifies that with debug logging on,
+// the raw request body is written to the log so an operator can inspect
+// UpdateOld and other plan.Changes fields the summary log lines omit.
+func TestApplyChangesHandler_DebugBodyDump(t *testing.T) {
+	webhook := createTestWebhook()
+
+	body, err := json.Marshal(plan.Changes{
+		UpdateNew: []*endpoint.Endpoint{
+			{DNSName: "diag.example.com", RecordType: "TXT", Targets: endpoint.Targets{`"heritage=external-dns"`}, RecordTTL: 3600},
+		},
+	})
+	if err != nil {
+		t.Fatalf("Failed to marshal changes: %v", err)
+	}
+
+	var buf bytes.Buffer
+	prevLevel := log.GetLevel()
+	prevOut := log.StandardLogger().Out
+	log.SetLevel(log.DebugLevel)
+	log.SetOutput(&buf)
+	defer func() {
+		log.SetLevel(prevLevel)
+		log.SetOutput(prevOut)
+	}()
+
+	req := httptest.NewRequest("POST", "/records", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+
+	webhook.applyChangesHandler(w, req)
+
+	if w.Code != http.StatusNoContent {
+		t.Fatalf("Status code = %v, want %v (logs: %s)", w.Code, http.StatusNoContent, buf.String())
+	}
+	if !bytes.Contains(buf.Bytes(), []byte("POST /records body:")) {
+		t.Errorf("expected debug log to contain body dump prefix, got: %s", buf.String())
+	}
+	if !bytes.Contains(buf.Bytes(), []byte("diag.example.com")) {
+		t.Errorf("expected debug log to contain the request body, got: %s", buf.String())
+	}
+}
+
+// TestApplyChangesHandler_NoDebugDumpAtInfoLevel verifies that at info level
+// (the default) the handler does not log the body and still serves the
+// request correctly -- so the diagnostic flag is opt-in.
+func TestApplyChangesHandler_NoDebugDumpAtInfoLevel(t *testing.T) {
+	webhook := createTestWebhook()
+
+	body, err := json.Marshal(plan.Changes{
+		Create: []*endpoint.Endpoint{
+			{DNSName: "quiet.example.com", RecordType: "A", Targets: endpoint.Targets{"192.0.2.1"}, RecordTTL: 3600},
+		},
+	})
+	if err != nil {
+		t.Fatalf("Failed to marshal changes: %v", err)
+	}
+
+	var buf bytes.Buffer
+	prevLevel := log.GetLevel()
+	prevOut := log.StandardLogger().Out
+	log.SetLevel(log.InfoLevel)
+	log.SetOutput(&buf)
+	defer func() {
+		log.SetLevel(prevLevel)
+		log.SetOutput(prevOut)
+	}()
+
+	req := httptest.NewRequest("POST", "/records", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+
+	webhook.applyChangesHandler(w, req)
+
+	if w.Code != http.StatusNoContent {
+		t.Fatalf("Status code = %v, want %v", w.Code, http.StatusNoContent)
+	}
+	if bytes.Contains(buf.Bytes(), []byte("POST /records body:")) {
+		t.Errorf("info level should not emit body dump; got: %s", buf.String())
+	}
+}
+
 // Integration test with HTTP server
 func TestWebhookServerIntegration(t *testing.T) {
 	config := config.Config{

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -134,6 +134,80 @@ func TestRecordsHandler(t *testing.T) {
 	}
 }
 
+// throttledProvider is a desecProvider that always reports an open deSEC
+// throttle window, so the handler mapping (RateLimitError -> 500 + Retry-After)
+// can be tested without driving a real retry loop.
+type throttledProvider struct{ retryAfter time.Duration }
+
+func (p throttledProvider) GetEndpoints(_ context.Context, _ string) ([]*endpoint.Endpoint, error) {
+	return nil, &provider.RateLimitError{RetryAfter: p.retryAfter}
+}
+
+func (p throttledProvider) ApplyChanges(_ context.Context, _ plan.Changes) error {
+	return &provider.RateLimitError{RetryAfter: p.retryAfter}
+}
+
+func (p throttledProvider) AdjustEndpoints(eps []*endpoint.Endpoint) ([]*endpoint.Endpoint, error) {
+	return eps, nil
+}
+
+func throttledWebhook(retryAfter time.Duration) webhook {
+	cfg := config.Config{DomainFilters: []string{"example.com"}}
+	return webhook{desecClient: throttledProvider{retryAfter: retryAfter}, config: cfg}
+}
+
+// A deSEC throttle must surface to external-dns as 500 (a retryable SoftError),
+// NEVER 429, which external-dns treats as a hard fatal error. The real
+// Retry-After is still exposed for operators even though external-dns ignores
+// it.
+func TestRecordsHandler_ThrottleReturns500Not429(t *testing.T) {
+	webhook := throttledWebhook(600 * time.Second)
+
+	log.SetLevel(log.ErrorLevel)
+	defer log.SetLevel(log.InfoLevel)
+
+	req := httptest.NewRequest("GET", "/records", nil)
+	w := httptest.NewRecorder()
+	webhook.recordsHandler(w, req)
+
+	if w.Code == http.StatusTooManyRequests {
+		t.Fatalf("recordsHandler returned 429; external-dns treats that as fatal")
+	}
+	if w.Code != http.StatusInternalServerError {
+		t.Fatalf("Status code = %v, want %v", w.Code, http.StatusInternalServerError)
+	}
+	if got := w.Header().Get("Retry-After"); got != "600" {
+		t.Errorf("Retry-After = %q, want \"600\"", got)
+	}
+}
+
+func TestApplyChangesHandler_ThrottleReturns500Not429(t *testing.T) {
+	webhook := throttledWebhook(600 * time.Second)
+
+	log.SetLevel(log.ErrorLevel)
+	defer log.SetLevel(log.InfoLevel)
+
+	body, _ := json.Marshal(plan.Changes{
+		Create: []*endpoint.Endpoint{
+			{DNSName: "x.example.com", RecordType: "A", Targets: endpoint.Targets{"192.0.2.1"}, RecordTTL: 3600},
+		},
+	})
+	req := httptest.NewRequest("POST", "/records", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	webhook.applyChangesHandler(w, req)
+
+	if w.Code == http.StatusTooManyRequests {
+		t.Fatalf("applyChangesHandler returned 429; external-dns treats that as fatal")
+	}
+	if w.Code != http.StatusInternalServerError {
+		t.Fatalf("Status code = %v, want %v", w.Code, http.StatusInternalServerError)
+	}
+	if got := w.Header().Get("Retry-After"); got != "600" {
+		t.Errorf("Retry-After = %q, want \"600\"", got)
+	}
+}
+
 func TestApplyChangesHandler(t *testing.T) {
 	tests := []struct {
 		name           string

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -135,9 +135,14 @@ func TestRecordsHandler(t *testing.T) {
 }
 
 // throttledProvider is a desecProvider that always reports an open deSEC
-// throttle window, so the handler mapping (RateLimitError -> 500 + Retry-After)
-// can be tested without driving a real retry loop.
-type throttledProvider struct{ retryAfter time.Duration }
+// throttle window, so the handler mapping (RateLimitError -> cache or
+// 500 + Retry-After) can be tested without driving a real retry loop. When
+// cached is set, CachedEndpoints returns it all-or-nothing.
+type throttledProvider struct {
+	retryAfter time.Duration
+	cached     []*endpoint.Endpoint
+	hasCache   bool
+}
 
 func (p throttledProvider) GetEndpoints(_ context.Context, _ string) ([]*endpoint.Endpoint, error) {
 	return nil, &provider.RateLimitError{RetryAfter: p.retryAfter}
@@ -149,6 +154,12 @@ func (p throttledProvider) ApplyChanges(_ context.Context, _ plan.Changes) error
 
 func (p throttledProvider) AdjustEndpoints(eps []*endpoint.Endpoint) ([]*endpoint.Endpoint, error) {
 	return eps, nil
+}
+
+func (p throttledProvider) Throttled() bool { return true }
+
+func (p throttledProvider) CachedEndpoints(_ []string) ([]*endpoint.Endpoint, bool) {
+	return p.cached, p.hasCache
 }
 
 func throttledWebhook(retryAfter time.Duration) webhook {
@@ -178,6 +189,54 @@ func TestRecordsHandler_ThrottleReturns500Not429(t *testing.T) {
 	}
 	if got := w.Header().Get("Retry-After"); got != "600" {
 		t.Errorf("Retry-After = %q, want \"600\"", got)
+	}
+}
+
+// While throttled, a full last-known-good cache is served as 200 rather than
+// failing, so external-dns keeps a correct view of the zone.
+func TestRecordsHandler_ServesCacheWhenWindowOpen(t *testing.T) {
+	cached := []*endpoint.Endpoint{
+		{DNSName: "a.example.com", RecordType: "A", Targets: endpoint.Targets{"192.0.2.1"}, RecordTTL: 3600},
+	}
+	webhook := webhook{
+		desecClient: throttledProvider{retryAfter: 600 * time.Second, cached: cached, hasCache: true},
+		config:      config.Config{DomainFilters: []string{"example.com"}},
+	}
+
+	log.SetLevel(log.ErrorLevel)
+	defer log.SetLevel(log.InfoLevel)
+
+	req := httptest.NewRequest("GET", "/records", nil)
+	w := httptest.NewRecorder()
+	webhook.recordsHandler(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("Status code = %v, want %v (cached serve)", w.Code, http.StatusOK)
+	}
+	var got []*endpoint.Endpoint
+	if err := json.NewDecoder(w.Body).Decode(&got); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(got) != 1 || got[0].DNSName != "a.example.com" {
+		t.Errorf("served endpoints = %v, want the cached set", got)
+	}
+}
+
+// A domain never fetched successfully has no cache, so the throttle must fall
+// through to 500 rather than serving a synthetic empty 200 -- an empty set
+// under --policy=sync would delete every record in the zone.
+func TestRecordsHandler_NoSyntheticEmptyWhenCacheMissing(t *testing.T) {
+	webhook := throttledWebhook(600 * time.Second) // hasCache defaults to false
+
+	log.SetLevel(log.ErrorLevel)
+	defer log.SetLevel(log.InfoLevel)
+
+	req := httptest.NewRequest("GET", "/records", nil)
+	w := httptest.NewRecorder()
+	webhook.recordsHandler(w, req)
+
+	if w.Code != http.StatusInternalServerError {
+		t.Fatalf("Status code = %v, want %v (no cache -> 500, not empty 200)", w.Code, http.StatusInternalServerError)
 	}
 }
 


### PR DESCRIPTION
Hello, @michelangelomo

This pull request accumulates all my changes to the external-dns-desec-provider I've made so far. They are present on my fork, https://github.com/sshine/external-dns-desec-provider and are released as the image [`ghcr.io/sshine/external-dns-desec-provider:v0.3.5`](https://github.com/sshine/external-dns-desec-provider/pkgs/container/external-dns-desec-provider). Thanks to @dhilgarth for providing solution and feedback to the HTTP 429 handling in sshine/external-dns-desec-provider#2.

It's totally okay if you don't have the time to review and merge these (it's a lot); this message can serve as a reminder to others that the fixes are available.

I've reordered the commits by importance and marked with bold fixes that completely broke my use of the webhook:

- **6ef6379 feat(provider): respect Retry-After to break the HTTP 429 reconcile loop**
- **fdd1ad3 fix(provider): strip trailing dot from /records DNSName**
- **6b49ad1 chore(deps): bump nrdcg/desec to v0.11.2 for apex subname fix**
- **95224bb fix(provider): apply DNS changes as one atomic bulk request per domain**
- **e4c29f9 fix(provider): fail fast on deSEC 429 without crashing external-dns**
- 745ba83 feat(provider): serve cached records during a throttle window
- b6defc7 feat(provider): proactive per-scope sliding-window rate limiters
- 50a2671 fix(provider): log throttle, decode failures, and promote fetch logs to info
- 4efa85e chore(provider): log POST body at debug level for plan.Changes diagnosis
- 8521f5b refactor(provider): drop unused GetRecords and dedupe the wait() guard
- 63bdffd chore(ci): bump all CI actions to non-deprecated Node versions
- c3e24bb chore(ci): bump cosign-release v2.2.4 -> v3.0.6
- 4fe96bb chore(ci): fixup for the CI actions version bump
- 4649d11 chore(ci): enable workflow_dispatch for regular CI on main
